### PR TITLE
Add bearer token authentication for API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Anthology is a two-tier catalogue that combines a Go API (powered by the [`chi`]
 * Go 1.22 with structured logging via `log/slog`.
 * HTTP routing handled by `chi`, with middleware for request IDs, timeouts, and structured logging.
 * Domain package `internal/items` exposes a repository interface with both in-memory and Postgres implementations.
-* Configuration is environment-driven (`DATA_STORE`, `DATABASE_URL`, `PORT`, `LOG_LEVEL`, `ALLOWED_ORIGINS`). When `DATA_STORE=memory` (the default), the API boots with a seeded in-memory catalogue to help demo the experience quickly.
+* Configuration is environment-driven (`DATA_STORE`, `DATABASE_URL`, `PORT`, `LOG_LEVEL`, `ALLOWED_ORIGINS`, `API_TOKEN`). When `DATA_STORE=memory` (the default), the API boots with a seeded in-memory catalogue to help demo the experience quickly.
+* When `API_TOKEN` is set, every `/api/*` request must send `Authorization: Bearer <token>`. Requests to `/health` remain public so uptime checks continue to work.
 * CORS is enabled via [`github.com/go-chi/cors`](https://github.com/go-chi/cors) and defaults to allowing `http://localhost:4200` and `http://localhost:8080`. Override with `ALLOWED_ORIGINS="https://example.com,https://admin.example.com"` when deploying.
 * Postgres persistence is implemented with `sqlx`; see [`migrations/0001_create_items.sql`](migrations/0001_create_items.sql) for the schema.
 
@@ -29,6 +30,7 @@ Anthology is a two-tier catalogue that combines a Go API (powered by the [`chi`]
 export DATA_STORE=memory
 export PORT=8080
 export ALLOWED_ORIGINS="http://localhost:4200,http://localhost:8080"
+export API_TOKEN="super-secret-token"
 go run ./cmd/api
 ```
 
@@ -50,6 +52,7 @@ export DATA_STORE=postgres
 export DATABASE_URL="postgres://anthology:anthology@localhost:5432/anthology?sslmode=disable"
 export PORT=8080
 export ALLOWED_ORIGINS="https://tracker.example.com"
+export API_TOKEN="super-secret-token"
 
 # Apply the migration (example)
 psql "$DATABASE_URL" -f migrations/0001_create_items.sql
@@ -76,7 +79,7 @@ go test ./...
 
 * Angular 20 standalone application located in `web/`.
 * Styling is powered by [`@angular/material`](https://www.npmjs.com/package/@angular/material) and its Material 3 design tokens. The global theme lives in [`web/src/styles.scss`](web/src/styles.scss).
-* The main page (`ItemsPageComponent`) provides a responsive catalogue view, inline editing, and CRUD actions that call the Go API.
+* The main page (`ItemsPageComponent`) provides a responsive catalogue view, inline editing, and CRUD actions that call the Go API. A dedicated login screen stores your bearer token locally and the application automatically attaches it to every request.
 * API base URL is resolved from the `<meta name="anthology-api">` tag (defaults to `http://localhost:8080/api`).
 * The UI seed data and layout offer a curated catalogue dashboard out of the box.
 
@@ -89,6 +92,8 @@ npm start                           # ng serve --open
 ```
 
 The dev server runs on `http://localhost:4200` and proxies requests directly to the API URL specified in the meta tag. To point at a different backend, update the meta tag in `web/src/index.html` (for local overrides you can edit it before serving).
+
+When you first load the app you will be redirected to the login screen. Paste the same value you configured for `API_TOKEN` on the API server and the Angular client will persist it in `localStorage` for subsequent visits. Use the “Log out” button in the toolbar to clear it at any time.
 
 ### Testing and linting
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DataStore      string
 	LogLevel       string
 	AllowedOrigins []string
+	APIToken       string
 }
 
 // Load reads configuration from environment variables with sensible defaults for local development.
@@ -25,6 +26,7 @@ func Load() (Config, error) {
 		DataStore:      strings.ToLower(getEnv("DATA_STORE", "memory")),
 		LogLevel:       strings.ToLower(getEnv("LOG_LEVEL", "info")),
 		AllowedOrigins: parseCSV(getEnv("ALLOWED_ORIGINS", "http://localhost:4200,http://localhost:8080")),
+		APIToken:       strings.TrimSpace(getEnv("API_TOKEN", "")),
 	}
 
 	portValue := getEnv("PORT", getEnv("HTTP_PORT", "8080"))

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -1,8 +1,10 @@
 package http
 
 import (
+	"crypto/subtle"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -26,4 +28,37 @@ func newSlogMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 			logger.Info("http request", "method", r.Method, "path", r.URL.Path, "status", recorder.status, "duration", duration.String())
 		})
 	}
+}
+
+func newTokenAuthMiddleware(expectedToken string) func(http.Handler) http.Handler {
+	expectedToken = strings.TrimSpace(expectedToken)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if expectedToken == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			const prefix = "Bearer "
+			authHeader := r.Header.Get("Authorization")
+			if !strings.HasPrefix(authHeader, prefix) {
+				unauthorized(w)
+				return
+			}
+
+			token := strings.TrimSpace(authHeader[len(prefix):])
+			if token == "" || subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) != 1 {
+				unauthorized(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func unauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	writeError(w, http.StatusUnauthorized, "authentication required")
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -41,6 +41,7 @@ func NewRouter(cfg config.Config, svc *items.Service, logger *slog.Logger) http.
 
 	handler := NewItemHandler(svc, logger)
 	r.Route("/api", func(r chi.Router) {
+		r.Use(newTokenAuthMiddleware(cfg.APIToken))
 		r.Route("/items", func(r chi.Router) {
 			r.Get("/", handler.List)
 			r.Post("/", handler.Create)

--- a/web/src/app/app.config.ts
+++ b/web/src/app/app.config.ts
@@ -1,9 +1,10 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withInterceptors, withInterceptorsFromDi } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
+import { authInterceptor } from './services/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -11,6 +12,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideAnimations(),
     provideRouter(routes),
-    provideHttpClient(withInterceptorsFromDi())
+    provideHttpClient(withInterceptors([authInterceptor]), withInterceptorsFromDi())
   ]
 };

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -1,9 +1,16 @@
 import { Routes } from '@angular/router';
 
+import { authGuard } from './services/auth.guard';
+
 export const routes: Routes = [
   {
     path: '',
+    canActivate: [authGuard],
     loadComponent: () => import('./pages/items/items-page.component').then((m) => m.ItemsPageComponent),
+  },
+  {
+    path: 'login',
+    loadComponent: () => import('./pages/login/login-page.component').then((m) => m.LoginPageComponent),
   },
   { path: '**', redirectTo: '' },
 ];

--- a/web/src/app/pages/items/items-page.component.html
+++ b/web/src/app/pages/items/items-page.component.html
@@ -1,6 +1,10 @@
 <mat-toolbar color="primary" class="toolbar">
   <span class="brand">Anthology</span>
   <span class="spacer"></span>
+  <button mat-button type="button" (click)="logout()" data-testid="logout-btn">
+    <mat-icon>logout</mat-icon>
+    Log out
+  </button>
   <button mat-flat-button color="accent" (click)="startCreate()" data-testid="add-item-btn">
     <mat-icon>library_add</mat-icon>
     Add item

--- a/web/src/app/pages/items/items-page.component.ts
+++ b/web/src/app/pages/items/items-page.component.ts
@@ -8,10 +8,11 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Item, ItemForm, ITEM_TYPE_LABELS } from '../../models/item';
+import { AuthService } from '../../services/auth.service';
 import { ItemService } from '../../services/item.service';
 import { ItemFormComponent } from '../../components/item-form/item-form.component';
 
@@ -53,8 +54,10 @@ type FormContext = CreateFormContext | EditFormContext;
 })
 export class ItemsPageComponent {
   private readonly itemService = inject(ItemService);
+  private readonly authService = inject(AuthService);
   private readonly snackBar = inject(MatSnackBar);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router);
 
   readonly displayedColumns = ['title', 'creator', 'itemType', 'releaseYear', 'updatedAt', 'actions'] as const;
   readonly items = signal<Item[]>([]);
@@ -67,6 +70,12 @@ export class ItemsPageComponent {
 
   constructor() {
     this.refresh();
+  }
+
+  logout(): void {
+    this.authService.clearToken();
+    this.items.set([]);
+    this.router.navigate(['/login']);
   }
 
   refresh(): void {

--- a/web/src/app/pages/login/login-page.component.html
+++ b/web/src/app/pages/login/login-page.component.html
@@ -1,0 +1,29 @@
+<div class="login-wrapper">
+  <mat-card class="login-card">
+    <mat-card-header>
+      <mat-card-title>Sign in to Anthology</mat-card-title>
+      <mat-card-subtitle>Provide your personal access token to continue.</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <form (ngSubmit)="submit()" [formGroup]="form" class="login-form">
+        <mat-form-field appearance="outline">
+          <mat-label>API token</mat-label>
+          <input matInput type="password" formControlName="token" autocomplete="off" required />
+          <mat-error *ngIf="tokenControl.hasError('required')">A token is required.</mat-error>
+        </mat-form-field>
+
+        <div class="actions">
+          <button mat-stroked-button type="button" (click)="clearToken()">Clear saved token</button>
+          <button mat-flat-button color="primary" type="submit">Continue</button>
+        </div>
+      </form>
+    </mat-card-content>
+
+    <mat-card-footer>
+      <p class="hint">
+        Tip: set the <code>API_TOKEN</code> environment variable on the API server and paste the same value here.
+      </p>
+    </mat-card-footer>
+  </mat-card>
+</div>

--- a/web/src/app/pages/login/login-page.component.scss
+++ b/web/src/app/pages/login/login-page.component.scss
@@ -1,0 +1,36 @@
+.login-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(63, 81, 181, 0.1), rgba(103, 58, 183, 0.15));
+  padding: 2rem;
+}
+
+.login-card {
+  max-width: 420px;
+  width: 100%;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+:host ::ng-deep code {
+  font-family: 'Roboto Mono', monospace;
+}

--- a/web/src/app/pages/login/login-page.component.ts
+++ b/web/src/app/pages/login/login-page.component.ts
@@ -1,0 +1,71 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { Router, ActivatedRoute, RouterModule } from '@angular/router';
+
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-login-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  templateUrl: './login-page.component.html',
+  styleUrl: './login-page.component.scss',
+})
+export class LoginPageComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly formBuilder = inject(FormBuilder);
+
+  readonly form = this.formBuilder.group({
+    token: ['', [Validators.required]],
+  });
+
+  constructor() {
+    const existing = this.authService.getToken();
+    if (existing) {
+      this.form.patchValue({ token: existing });
+    }
+  }
+
+  get tokenControl() {
+    return this.form.controls.token;
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const token = this.tokenControl.value?.trim();
+    if (!token) {
+      this.tokenControl.setErrors({ required: true });
+      return;
+    }
+
+    this.authService.setToken(token);
+
+    const redirectTo = this.route.snapshot.queryParamMap.get('redirectTo');
+    this.router.navigateByUrl(redirectTo || '/');
+  }
+
+  clearToken(): void {
+    this.authService.clearToken();
+    this.form.reset({ token: '' });
+  }
+
+}

--- a/web/src/app/services/auth.guard.ts
+++ b/web/src/app/services/auth.guard.ts
@@ -1,0 +1,17 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = (_route, state): boolean | UrlTree => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login'], {
+    queryParams: state.url ? { redirectTo: state.url } : undefined,
+  });
+};

--- a/web/src/app/services/auth.interceptor.ts
+++ b/web/src/app/services/auth.interceptor.ts
@@ -1,0 +1,33 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+
+import { AuthService } from './auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (request, next) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  const token = authService.getToken();
+  if (token) {
+    request = request.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  }
+
+  return next(request).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        authService.clearToken();
+        void router.navigate(['/login'], {
+          queryParams: { redirectTo: router.url !== '/login' ? router.url : undefined },
+        });
+      }
+
+      return throwError(() => error);
+    })
+  );
+};

--- a/web/src/app/services/auth.service.ts
+++ b/web/src/app/services/auth.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly storageKey = 'anthology.apiToken';
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly tokenSubject = new BehaviorSubject<string | null>(this.readToken());
+
+  tokenChanges(): Observable<string | null> {
+    return this.tokenSubject.asObservable();
+  }
+
+  getToken(): string | null {
+    return this.tokenSubject.value;
+  }
+
+  isAuthenticated(): boolean {
+    return this.tokenSubject.value !== null;
+  }
+
+  setToken(token: string): void {
+    const normalized = token.trim();
+    if (normalized === '') {
+      this.clearToken();
+      return;
+    }
+
+    this.tokenSubject.next(normalized);
+    if (this.isBrowser) {
+      window.localStorage.setItem(this.storageKey, normalized);
+    }
+  }
+
+  clearToken(): void {
+    this.tokenSubject.next(null);
+    if (this.isBrowser) {
+      window.localStorage.removeItem(this.storageKey);
+    }
+  }
+
+  private readToken(): string | null {
+    if (!this.isBrowser) {
+      return null;
+    }
+
+    const stored = window.localStorage.getItem(this.storageKey);
+    if (!stored) {
+      return null;
+    }
+
+    const normalized = stored.trim();
+    return normalized === '' ? null : normalized;
+  }
+}


### PR DESCRIPTION
## Summary
- secure API routes with a bearer token middleware controlled by the new API_TOKEN config
- add an Angular login screen, auth service, and interceptor to store the token and attach it to requests
- update the UI with a logout button and document the authentication flow in the README

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690feea9638c8321acd46455e9c842cc)