### PR TITLE
Add GitHub Actions workflow for Anthology deploy

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -1,0 +1,78 @@
+name: CI build → push → trigger deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-trigger:
+    runs-on: ubuntu-24.04-arm
+    environment:
+      name: crystal1
+    env:
+      IMAGE_REG: ${{ vars.IMAGE_REG }}
+      IMAGE_REPO: ${{ vars.IMAGE_REPO }}
+      MANAGER_HOST: ${{ vars.MANAGER_HOST }}
+      MANAGER_REPO_PATH: ${{ vars.MANAGER_REPO_PATH }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive TAG
+        id: meta
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REG }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Debug refs
+        run: |
+          echo "IMAGE_REG=${IMAGE_REG}"
+          echo "IMAGE_REPO=${IMAGE_REPO}"
+          echo "TAG=${{ steps.meta.outputs.TAG }}"
+
+      - name: Build and push anthology image
+        env:
+          TAG: ${{ steps.meta.outputs.TAG }}
+        run: |
+          set -euo pipefail
+          : "${IMAGE_REG:?Missing vars.IMAGE_REG repository variable}"
+          : "${IMAGE_REPO:?Missing vars.IMAGE_REPO repository variable}"
+          IMAGE="${IMAGE_REG}/${IMAGE_REPO}:${TAG}"
+          echo "Building ${IMAGE}"
+          docker buildx build \
+            --platform=linux/arm64/v8 \
+            -f Dockerfile \
+            -t "${IMAGE}" \
+            --push \
+            .
+
+      - name: Install SSH key & known_hosts
+        env:
+          DEPLOY_KEY: ${{ secrets.LOCAL_REPO_DEPLOY_KEY }}
+          KNOWN_HOSTS: ${{ secrets.LOCAL_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Push main to local bare repo (trigger hook)
+        env:
+          TAG: ${{ steps.meta.outputs.TAG }}
+        run: |
+          set -euo pipefail
+          : "${MANAGER_HOST:?Missing vars.MANAGER_HOST repository variable}"
+          : "${MANAGER_REPO_PATH:=/srv/git/anthology.git}"
+          echo "Triggering deploy via ${MANAGER_HOST}:${MANAGER_REPO_PATH}"
+          git remote add local "ssh://git@${MANAGER_HOST}/${MANAGER_REPO_PATH}"
+          git push --force local HEAD:refs/heads/main


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Anthology container image for arm64
- push the image to registry.bitofbytes.io using repository variables for registry configuration
- trigger the remote post-receive hook by pushing to the bare repository over SSH

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d53e306088321a2c940add99f91b8)