### PR TITLE
Add Angular UI build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Build artifacts
+bin
+web/dist
+
+# Node dependencies are restored during the Docker build
+web/node_modules
+
+# VCS and editor files
+.git
+.gitignore
+.dockerignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,33 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.22 AS builder
-WORKDIR /app
 
+ARG GO_VERSION=1.22
+ARG NODE_VERSION=20
+
+FROM node:${NODE_VERSION}-bookworm AS ui-deps
+WORKDIR /ui
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+FROM node:${NODE_VERSION}-bookworm AS ui-builder
+WORKDIR /ui
+COPY --from=ui-deps /ui/node_modules ./node_modules
+COPY web/ ./
+RUN npm run build
+
+FROM golang:${GO_VERSION} AS go-builder
+WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
-
 COPY cmd ./cmd
 COPY internal ./internal
 COPY migrations ./migrations
-
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/anthology ./cmd/api
 
 FROM gcr.io/distroless/base-debian12
-
-COPY --from=builder /bin/anthology /anthology
-COPY migrations /migrations
-
+WORKDIR /
+COPY --from=go-builder /bin/anthology /anthology
+COPY --from=go-builder /migrations /migrations
+COPY --from=ui-builder /ui/dist /web/dist
 ENV PORT=8080
 EXPOSE 8080
-
 ENTRYPOINT ["/anthology"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+SHELL := /bin/bash
+
+APP_NAME ?= anthology
+UI_DIR := web
+UI_DIST := $(UI_DIR)/dist
+GO_CMD := ./cmd/api
+
+.PHONY: help tidy fmt test ui-install ui-build build run clean docker-build docker-run
+
+help:
+@echo "Commonly used targets:"
+@echo "  make build        Build the Go API and Angular UI"
+@echo "  make test         Run Go unit tests"
+@echo "  make ui-build     Build the Angular application"
+@echo "  make docker-build Build the multi-stage Docker image"
+
+fmt:
+go fmt ./...
+
+tidy:
+go mod tidy
+
+test:
+go test ./...
+
+ui-install:
+cd $(UI_DIR) && npm ci
+
+ui-build: ui-install
+cd $(UI_DIR) && npm run build
+
+build: ui-build
+mkdir -p bin
+CGO_ENABLED=0 GOOS=linux go build -o bin/$(APP_NAME) $(GO_CMD)
+
+run:
+go run $(GO_CMD)
+
+clean:
+rm -rf bin $(UI_DIST)
+
+docker-build:
+docker build -t $(APP_NAME):latest .
+
+docker-run:
+docker run --rm -p 8080:8080 $(APP_NAME):latest


### PR DESCRIPTION
## Summary
- update the Dockerfile to build the Angular frontend and Go API with multi-stage builds
- add a Makefile with shortcuts for building, testing, and Docker workflows
- add a .dockerignore to keep the Docker context lean

## Testing
- go test ./cmd/... ./internal/...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910112673c4832182c2de6ed52a8ac7)