### PR TITLE
Load Anthology secrets from Swarm files

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -31,8 +31,10 @@ RUN addgroup -S anthology \
 
 ENV PORT=8080
 ENV LOG_LEVEL=${LOG_LEVEL}
+ENV DATABASE_URL_FILE=/run/secrets/anthology_database_url
+ENV API_TOKEN_FILE=/run/secrets/anthology_api_token
 
 USER anthology
 
 EXPOSE 8080
-ENTRYPOINT ["./anthology"]
+CMD ["./anthology"]


### PR DESCRIPTION
## Summary
- allow the Go config loader to read `DATABASE_URL` and `API_TOKEN` from either env vars, `<NAME>_FILE` overrides, or the default Swarm secret mounts under `/run/secrets/anthology_*`
- set the runtime image to point at those default secret paths so credentials stay out of the Dockerfile
- document the required Docker secrets, how to rotate them, and the SQL needed to provision the Postgres role/db

## Testing
- `GOCACHE=$(mktemp -d) go test ./...`
