### PR TITLE
Fix SPA fallback routing

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -58,8 +58,7 @@ func NewRouter(cfg config.Config, svc *items.Service, logger *slog.Logger) http.
 	})
 
 	spa := newSPAHandler("web-dist", logger)
-	r.Get("/*", spa)
-	r.Head("/*", spa)
+	r.NotFound(spa)
 
 	return r
 }


### PR DESCRIPTION
## Summary
- replace the wide `GET /*`/`HEAD /*` routes with `chi.NotFound(spa)` so any non-API path correctly falls back to `web-dist/index.html`
- keeps API routes untouched while letting Angular paths such as `/items/123` load without 404s

## Testing
- `GOCACHE=$(mktemp -d) go test ./...`
