### PR TITLE
Automatically run migrations on startup

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 	"anthology/internal/items"
 	"anthology/internal/platform/database"
 	"anthology/internal/platform/logging"
+	"anthology/internal/platform/migrate"
 )
 
 func main() {
@@ -80,6 +81,12 @@ func buildRepository(ctx context.Context, cfg config.Config, logger *slog.Logger
 	cleanup := func() {
 		_ = db.Close()
 	}
+
+	if err := migrate.Apply(ctx, db, logger); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
 	logger.Info("connected to postgres")
 	return items.NewPostgresRepository(db), cleanup, nil
 }

--- a/internal/platform/migrate/migrate.go
+++ b/internal/platform/migrate/migrate.go
@@ -1,0 +1,107 @@
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"log/slog"
+
+	"github.com/jmoiron/sqlx"
+
+	"anthology/migrations"
+)
+
+const schemaMigrationsTable = "schema_migrations"
+
+// Apply runs any pending SQL migrations bundled with the binary.
+func Apply(ctx context.Context, db *sqlx.DB, logger *slog.Logger) error {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			name TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		);`, schemaMigrationsTable)); err != nil {
+		return fmt.Errorf("migrate: create schema table: %w", err)
+	}
+
+	applied, err := fetchApplied(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	files, err := readMigrationFiles()
+	if err != nil {
+		return err
+	}
+
+	for _, name := range files {
+		if applied[name] {
+			continue
+		}
+
+		src, err := migrations.Files.ReadFile(name)
+		if err != nil {
+			return fmt.Errorf("migrate: read %s: %w", name, err)
+		}
+
+		if _, err := db.ExecContext(ctx, string(src)); err != nil {
+			return fmt.Errorf("migrate: exec %s: %w", name, err)
+		}
+
+		if _, err := db.ExecContext(ctx,
+			fmt.Sprintf("INSERT INTO %s (name) VALUES ($1)", schemaMigrationsTable),
+			name,
+		); err != nil {
+			return fmt.Errorf("migrate: record %s: %w", name, err)
+		}
+
+		if logger != nil {
+			logger.Info("migration applied", "name", name)
+		}
+	}
+
+	return nil
+}
+
+func fetchApplied(ctx context.Context, db *sqlx.DB) (map[string]bool, error) {
+	rows, err := db.QueryxContext(ctx, fmt.Sprintf(`SELECT name FROM %s`, schemaMigrationsTable))
+	if err != nil {
+		// table creation should guarantee existence, so propagate errors here
+		return nil, fmt.Errorf("migrate: fetch applied: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("migrate: scan applied: %w", err)
+		}
+		applied[name] = true
+	}
+	return applied, rows.Err()
+}
+
+func readMigrationFiles() ([]string, error) {
+	entries, err := fs.ReadDir(migrations.Files, ".")
+	if err != nil {
+		return nil, fmt.Errorf("migrate: read dir: %w", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if strings.HasSuffix(name, ".sql") {
+			files = append(files, name)
+		}
+	}
+
+	sort.Strings(files)
+	return files, nil
+}

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// Files exposes all SQL migrations embedded into the binary.
+//
+//go:embed *.sql
+var Files embed.FS


### PR DESCRIPTION
## Summary
- embed the SQL migration files into the API binary
- add a lightweight migration runner that applies any pending files on startup
- ensure the Postgres schema is created automatically when the containers boot

## Testing
- go test ./...
