### PR TITLE
Fix HTTPS API URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ go test ./...
 * Styling is powered by [`@angular/material`](https://www.npmjs.com/package/@angular/material) and its Material 3 design tokens. The global theme lives in [`web/src/styles.scss`](web/src/styles.scss).
 * The main page (`ItemsPageComponent`) provides a responsive catalogue view, inline editing, and CRUD actions that call the Go API. A dedicated login screen stores your bearer token locally and the application automatically attaches it to every request.
 * API base URL is resolved from the `<meta name="anthology-api">` tag (defaults to `http://localhost:8080/api`).
+  Deployments can override this without rebuilding by setting `window.NG_APP_API_URL` before the Angular bundle loads (e.g., inject `<script>window.NG_APP_API_URL='https://example.com/api';</script>` in the hosting template).
 * The UI seed data and layout offer a curated catalogue dashboard out of the box.
 
 ### Development workflow

--- a/web/src/app/config/environment.ts
+++ b/web/src/app/config/environment.ts
@@ -1,7 +1,13 @@
 const meta = typeof document !== 'undefined' ? document.querySelector('meta[name="anthology-api"]') : null;
-const metaUrl = meta?.getAttribute('content')?.trim();
-const globalUrl = (globalThis as { NG_APP_API_URL?: string }).NG_APP_API_URL;
+const metaUrl = meta?.getAttribute('content')?.trim() || null;
+const globalUrl = (globalThis as { NG_APP_API_URL?: string }).NG_APP_API_URL?.trim() || null;
+const locationOrigin = typeof window !== 'undefined' ? `${window.location.origin}/api` : null;
 
+const isHttpsPage = typeof window !== 'undefined' && window.location.protocol === 'https:';
+const safeMetaUrl = isHttpsPage && metaUrl?.startsWith('http:') ? null : metaUrl;
+const fallbackUrl = isHttpsPage ? locationOrigin : 'http://localhost:8080/api';
+
+// Allow hosts to override the API URL via a global before falling back to the baked-in meta tag.
 export const environment = {
-  apiUrl: metaUrl || globalUrl || 'http://localhost:8080/api'
+  apiUrl: globalUrl || safeMetaUrl || fallbackUrl || 'http://localhost:8080/api'
 };


### PR DESCRIPTION
## Summary
- avoid hard-coding http://localhost:8080/api when the UI is served over HTTPS
- allow deployments to inject a secure API URL through `window.NG_APP_API_URL`
- document the override option so hosts know how to point at their API

## Testing
- not run