### PR TITLE
Enforce API token requirement for non-dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 *.log
 coverage.out
+.cache/
 
 # Node / Angular
 web/node_modules/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,10 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("DATA_STORE is postgres but DATABASE_URL is not set")
 	}
 
+	if !strings.EqualFold(cfg.Environment, "development") && cfg.APIToken == "" {
+		return Config{}, fmt.Errorf("API_TOKEN is required when APP_ENV=%s", cfg.Environment)
+	}
+
 	return cfg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadAllowsEmptyTokenInDevelopment(t *testing.T) {
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("DATA_STORE", "memory")
+	t.Setenv("PORT", "8080")
+	t.Setenv("API_TOKEN", "")
+	t.Setenv("API_TOKEN_FILE", "")
+	t.Setenv("DATABASE_URL", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if cfg.APIToken != "" {
+		t.Fatalf("expected no API token in development, got %q", cfg.APIToken)
+	}
+}
+
+func TestLoadRequiresTokenOutsideDevelopment(t *testing.T) {
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("DATA_STORE", "memory")
+	t.Setenv("PORT", "8080")
+	t.Setenv("API_TOKEN", "")
+	t.Setenv("API_TOKEN_FILE", "")
+	t.Setenv("DATABASE_URL", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when API token missing outside development")
+	}
+	if !strings.Contains(err.Error(), "API_TOKEN is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadAcceptsTokenOutsideDevelopment(t *testing.T) {
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("DATA_STORE", "memory")
+	t.Setenv("PORT", "8080")
+	t.Setenv("API_TOKEN", "super-secret")
+	t.Setenv("DATABASE_URL", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.APIToken != "super-secret" {
+		t.Fatalf("expected API token to be preserved, got %q", cfg.APIToken)
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -44,6 +44,9 @@ func NewRouter(cfg config.Config, svc *items.Service, logger *slog.Logger) http.
 	})
 
 	handler := NewItemHandler(svc, logger)
+	if strings.TrimSpace(cfg.APIToken) == "" {
+		logger.Warn("API token authentication disabled; /api endpoints are unauthenticated")
+	}
 	r.Route("/api", func(r chi.Router) {
 		r.Use(newTokenAuthMiddleware(cfg.APIToken))
 		r.Route("/items", func(r chi.Router) {


### PR DESCRIPTION
## Summary
- fail fast when `APP_ENV` is not `development` and no API token is provided
- log a warning any time the router starts without a configured API token
- add dedicated configuration tests and ignore the Go build cache directory

## Testing
- `GOCACHE=$(pwd)/.cache/go go test ./...`
