### PR TITLE
Adopt Alegreya font family across the UI

### DIFF
--- a/web/src/app/components/sidebar/sidebar.component.scss
+++ b/web/src/app/components/sidebar/sidebar.component.scss
@@ -36,8 +36,10 @@
 
 .brand-title {
     font-size: 1.2rem;
-    font-weight: 600;
+    font-family: 'Alegreya SC', 'Alegreya Sans', 'Alegreya', serif;
+    font-weight: 500;
     letter-spacing: 0.02em;
+    text-transform: none;
 }
 
 .nav {
@@ -54,7 +56,8 @@
     border-radius: 0.65rem;
     color: inherit;
     text-decoration: none;
-    font-weight: 500;
+    font-family: 'Alegreya Sans', 'Alegreya', 'Segoe UI', sans-serif;
+    font-weight: 600;
     line-height: 1.2;
     transition: background 200ms ease, color 200ms ease, transform 200ms ease, box-shadow 200ms ease;
     position: relative;

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -1,11 +1,13 @@
 @use '@angular/material' as mat;
 
+@import url('https://fonts.googleapis.com/css2?family=Alegreya+SC:wght@400;500&family=Alegreya+Sans:wght@500;600;700&family=Alegreya:wght@400;500;600;700&display=swap');
+
 $anthology-theme: mat.define-theme((color: (theme-type: light,
                 primary: mat.$azure-palette,
                 tertiary: mat.$rose-palette,
             ),
-            typography: (plain-family: ('Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif),
-                brand-family: ('Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif),
+            typography: (plain-family: ('Alegreya', 'Georgia', 'Times New Roman', serif),
+                brand-family: ('Alegreya Sans', 'Alegreya', 'Segoe UI', sans-serif),
                 bold-weight: 700,
                 medium-weight: 600,
                 regular-weight: 400,
@@ -23,9 +25,31 @@ body {
 
 body {
     margin: 0;
-    font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-family: 'Alegreya', 'Georgia', 'Times New Roman', serif;
     background: var(--mat-sys-surface-container);
     color: var(--mat-sys-on-surface);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.mat-h1,
+.mat-h2,
+.mat-h3,
+.mat-h4,
+.mat-h5,
+.mat-h6,
+.mat-subtitle-1,
+.mat-subtitle-2,
+.mat-title-large,
+.mat-title-medium,
+.mat-title-small {
+    font-family: 'Alegreya Sans', 'Alegreya', 'Segoe UI', sans-serif;
+    font-weight: 600;
+    letter-spacing: 0.01em;
 }
 
 button {


### PR DESCRIPTION
## Summary
- load the Alegreya family from Google Fonts and configure the Angular Material theme to use it
- switch global body and heading styles to Alegreya serif and sans-serif variants for a literary tone
- update sidebar branding and navigation typography to align with the new font system

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913eb05dba48321a4e806d17dc0a19d)