### PR TITLE
Increase typography sizes for sidebar header and item table headers

### DIFF
--- a/web/src/app/components/sidebar/sidebar.component.scss
+++ b/web/src/app/components/sidebar/sidebar.component.scss
@@ -35,7 +35,7 @@
 }
 
 .brand-title {
-    font-size: 1.2rem;
+    font-size: 2rem;
     font-family: 'Alegreya SC', 'Alegreya Sans', 'Alegreya', serif;
     font-weight: 500;
     letter-spacing: 0.02em;

--- a/web/src/app/pages/items/items-page.component.scss
+++ b/web/src/app/pages/items/items-page.component.scss
@@ -81,7 +81,7 @@ mat-card {
 .items-table th {
     font-weight: 600;
     text-transform: uppercase;
-    font-size: 0.75rem;
+    font-size: 1rem;
     letter-spacing: 0.08em;
     color: var(--mat-sys-on-surface-variant);
     border-bottom: 1px solid var(--mat-sys-outline-variant);


### PR DESCRIPTION
## Summary
- enlarge the Anthology sidebar brand title to 2rem to emphasize the header
- increase the items table header font size to 1rem for readability

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f22ca4288321bc7800081d0c2f5f)