### PR TITLE
Remove duplicate creator details from items table

### DIFF
--- a/web/src/app/pages/items/items-page.component.html
+++ b/web/src/app/pages/items/items-page.component.html
@@ -10,7 +10,6 @@
                             <th mat-header-cell *matHeaderCellDef>Title</th>
                             <td mat-cell *matCellDef="let item" (click)="startEdit(item)">
                                 <div class="item-title">{{ item.title }}</div>
-                                <div class="item-meta">{{ item.creator || 'Unknown creator' }}</div>
                             </td>
                         </ng-container>
 

--- a/web/src/app/pages/items/items-page.component.scss
+++ b/web/src/app/pages/items/items-page.component.scss
@@ -105,11 +105,6 @@ mat-card {
     font-weight: 600;
 }
 
-.item-meta {
-    font-size: 0.85rem;
-    color: var(--mat-sys-on-surface-variant);
-}
-
 .actions {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
## Summary
- stop rendering the creator beneath the title in the items table so the column only shows the title
- remove the unused styling that supported the secondary creator line

## Testing
- not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f553e96483219cfccb0321ce9347)