### PR TITLE
Update docs for API and UI separation

### DIFF
--- a/docs/architecture/go-startup.md
+++ b/docs/architecture/go-startup.md
@@ -29,5 +29,5 @@ flowchart TD
 - `logging.New()` builds the global `slog.Logger` instance used across packages.
 - `buildRepository()` either seeds an in-memory repo (local/demo) or initializes Postgres, runs migrations, and wires `items.PostgresRepository`.
 - `items.Service` encapsulates validation plus CRUD orchestration; it is injected into HTTP handlers.
-- `http.NewRouter` composes middleware, auth, item endpoints, session handlers, and the SPA file server.
+- `http.NewRouter` composes middleware, auth, session handlers, and item endpoints. Static assets moved to the standalone UI container, so non-API paths return standard 404 responses.
 - The HTTP server runs `ListenAndServe` in a goroutine; the main goroutine blocks on the signal-aware context and then calls `srv.Shutdown` with a timeout to drain connections gracefully.

--- a/docs/architecture/material-design.md
+++ b/docs/architecture/material-design.md
@@ -7,6 +7,7 @@ This note captures how the Anthology frontend applies [Material Design](https://
 - **Design language:** The UI follows Material Design 3; use the Material guidance above for color, typography, and motion decisions.
 - **Component library:** [Angular Material](https://material.angular.io/) is installed via `@angular/material` and drives theming plus the component primitives (table, toolbar, snack-bar, etc.).
 - **Theme definition:** `web/src/styles.scss` imports `@angular/material` with `@use '@angular/material' as mat;` and defines the `$anthology-theme` tokens, including the Azure and Rose palettes along with the Inter/Segoe/Roboto font stack. `mat.core()`, `mat.all-component-themes()`, and `mat.all-component-typographies()` are included globally so standalone components automatically inherit the theme.
+- **Runtime configuration:** Because the UI is deployed independently of the API, `Docker/ui/entrypoint.sh` rewrites `web/dist/web/browser/assets/runtime-config.js` at container start when `NG_APP_API_URL` is present so static hosts can target any Anthology API instance without rebuilding.
 
 ## How the theme is applied
 

--- a/docs/planning/anthology.md
+++ b/docs/planning/anthology.md
@@ -20,9 +20,9 @@ Goal: list items (books, records, games) with core metadata via CRUD API and Ang
 ### Backend (Go)
 - Create a Go module (`cmd/api`, `internal/…`) following Clean Architecture or layered structure.
 - Define Postgres schema using migrations (e.g., `golang-migrate`). Tables: `items`, `item_categories`, `platforms`, `item_formats`, maybe `tags` pivot tables later. For MVP, single `items` table with enum-ish fields (`type`, `title`, `creator`, `release_year`, `notes`, `created_at`, `updated_at`).
-- Build REST API with the [`chi`](https://github.com/go-chi/chi) router. Endpoints: `POST /items`, `GET /items`, `GET /items/{id}`, `PUT /items/{id}`, `DELETE /items/{id}`. Provide validation, error handling, loggers (structured logs). Add configuration via environment variables (12-factor style), support `.env` for local dev.
+- Build REST API with the [`chi`](https://github.com/go-chi/chi) router. Endpoints: `POST /items`, `GET /items`, `GET /items/{id}`, `PUT /items/{id}`, `DELETE /items/{id}`. Provide validation, error handling, loggers (structured logs). Add configuration via environment variables (12-factor style), support `.env` for local dev. Keep the API JSON-only—the Angular bundle is served independently.
 - Persistence layer using repository interface, transaction handling, context propagation, unit tests with test containers or mocking DB using `sqlmock`.
-- Containerize API with multi-stage Dockerfile (build binary → minimal runtime). Provide make targets or scripts that wire Go API + Postgres locally without needing Compose in-repo.
+- Containerize API with multi-stage Dockerfile (build binary → minimal runtime). Provide make targets or scripts that wire Go API + Postgres locally without needing Compose in-repo. Package the Angular UI in its own nginx-based image so deployments can update each tier separately.
 
 ### Frontend (Angular)
 - Scaffold Angular app with routing, state management (NgRx optional later), shared module. Minimal layout (toolbar, navigation).

--- a/web/README.md
+++ b/web/README.md
@@ -22,7 +22,7 @@ The client listens on `http://localhost:4200`. API calls target the URL exposed 
 npm run build
 ```
 
-Bundles are emitted under `dist/web/` and can be served by any static host (for example, nginx in front of the Go API).
+Bundles are emitted under `dist/web/` and can be served by any static host (for example, nginx in front of the Go API). The production container defined in `Docker/Dockerfile.ui` rewrites `assets/runtime-config.js` at startup when `NG_APP_API_URL` is set so each deployment can point at a different Anthology API instance without rebuilding.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- note that the Go API and Angular UI deploy as separate services
- document the API-only router surface and session endpoints
- clarify how the nginx UI container rewrites runtime configuration for different API URLs

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915370d074c83218c4bc3afbbf6db36)