### PR TITLE
Prevent items page loading bar from shifting layout

### DIFF
--- a/web/src/app/pages/items/items-page.component.scss
+++ b/web/src/app/pages/items/items-page.component.scss
@@ -67,6 +67,15 @@
 mat-card {
     border-radius: 20px;
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+    position: relative;
+    overflow: hidden;
+}
+
+mat-progress-bar {
+    position: absolute;
+    inset: 0 0 auto;
+    pointer-events: none;
+    z-index: 1;
 }
 
 .table-wrapper {


### PR DESCRIPTION
## Summary
- keep the items page loading indicator positioned absolutely so the card content no longer shifts
- ensure the card hides overflow so the progress bar overlays its top edge cleanly

## Testing
- not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69168b38e9d483218c1b880921c79564)