### PR TITLE
Polish library and add item layouts

### DIFF
--- a/web/src/app/pages/add-item/add-item-page.component.html
+++ b/web/src/app/pages/add-item/add-item-page.component.html
@@ -1,9 +1,4 @@
 <section class="add-item-page">
-    <button mat-button type="button" class="back-link" routerLink="/">
-        <mat-icon>arrow_back</mat-icon>
-        Back to library
-    </button>
-
     <mat-card>
         <mat-card-header>
             <mat-card-title>Add a new item</mat-card-title>

--- a/web/src/app/pages/add-item/add-item-page.component.scss
+++ b/web/src/app/pages/add-item/add-item-page.component.scss
@@ -3,20 +3,16 @@
 }
 
 .add-item-page {
+    --page-gutter: clamp(1.5rem, 3vw, 4rem);
     width: 100%;
     max-width: 1120px;
     margin: 0 auto;
-    padding: 2.5rem clamp(1.5rem, 3vw, 4rem) 3rem;
+    padding: var(--page-gutter) var(--page-gutter) 3rem;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
     color: var(--mat-sys-on-surface);
-}
-
-.back-link {
-    width: fit-content;
-    color: var(--mat-sys-on-surface-variant);
 }
 
 mat-card {

--- a/web/src/app/pages/items/items-page.component.html
+++ b/web/src/app/pages/items/items-page.component.html
@@ -1,46 +1,42 @@
 <div class="page">
-    <header class="page-header">
-        <div class="page-heading">
-            <p class="eyebrow">Library</p>
+    <div class="filters-panel">
+        <div class="filters">
+            <mat-form-field appearance="outline" class="type-select">
+                <mat-label>Type</mat-label>
+                <mat-select [value]="typeFilter()" (valueChange)="setTypeFilter($event)">
+                    <mat-option *ngFor="let option of typeOptions" [value]="option.value">
+                        {{ option.label }}
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+
+            <div class="letter-filter" role="list">
+                <button
+                    mat-button
+                    type="button"
+                    class="letter-button"
+                    [class.active]="letterFilter() === 'ALL'"
+                    (click)="setLetterFilter('ALL')"
+                >
+                    All
+                </button>
+                <button
+                    mat-button
+                    type="button"
+                    class="letter-button"
+                    *ngFor="let letter of alphabet"
+                    [class.active]="letterFilter() === letter"
+                    (click)="setLetterFilter(letter)"
+                >
+                    {{ letter }}
+                </button>
+            </div>
         </div>
-    </header>
+    </div>
     <div class="layout">
         <section class="items-panel">
             <mat-card>
                 <mat-progress-bar *ngIf="loading()" mode="indeterminate"></mat-progress-bar>
-
-                <div class="filters">
-                    <mat-form-field appearance="outline" class="type-select">
-                        <mat-label>Type</mat-label>
-                        <mat-select [value]="typeFilter()" (valueChange)="setTypeFilter($event)">
-                            <mat-option *ngFor="let option of typeOptions" [value]="option.value">
-                                {{ option.label }}
-                            </mat-option>
-                        </mat-select>
-                    </mat-form-field>
-
-                    <div class="letter-filter" role="list">
-                        <button
-                            mat-button
-                            type="button"
-                            class="letter-button"
-                            [class.active]="letterFilter() === 'ALL'"
-                            (click)="setLetterFilter('ALL')"
-                        >
-                            All
-                        </button>
-                        <button
-                            mat-button
-                            type="button"
-                            class="letter-button"
-                            *ngFor="let letter of alphabet"
-                            [class.active]="letterFilter() === letter"
-                            (click)="setLetterFilter(letter)"
-                        >
-                            {{ letter }}
-                        </button>
-                    </div>
-                </div>
 
                 <ng-container *ngIf="hasFilteredItems(); else filteredFallback">
                     <div class="table-wrapper">

--- a/web/src/app/pages/items/items-page.component.scss
+++ b/web/src/app/pages/items/items-page.component.scss
@@ -3,54 +3,25 @@
 }
 
 .page {
+    --layout-gap: 2rem;
     min-height: 100%;
-    padding: 2.5rem clamp(1.5rem, 3vw, 4rem) 3rem;
+    padding: var(--layout-gap) clamp(1.5rem, 3vw, 4rem) 3rem;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: var(--layout-gap);
 }
 
-.page-header {
+.filters-panel {
+    padding-block: 0.25rem;
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1.5rem;
-}
-
-.add-button {
-    align-self: center;
-    white-space: nowrap;
-}
-
-.page-heading {
-    max-width: 560px;
-}
-
-.eyebrow {
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.18em;
-    font-weight: 600;
-    margin: 0 0 0.25rem;
-    color: var(--mat-sys-on-surface-variant);
-}
-
-.page-header h1 {
-    margin: 0;
-    font-size: clamp(1.75rem, 2.4vw, 2.5rem);
-}
-
-.subtitle {
-    margin: 0.35rem 0 0;
-    color: var(--mat-sys-on-surface-variant);
+    justify-content: flex-start;
 }
 
 .layout {
     display: flex;
     flex: 1 1 auto;
     flex-wrap: wrap;
-    gap: 2rem;
+    gap: var(--layout-gap);
     align-items: flex-start;
 }
 
@@ -97,7 +68,6 @@ mat-progress-bar {
     background: color-mix(in srgb, #e8f5ef 80%, white);
     border-radius: 1rem;
     box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
-    margin-bottom: 0.9rem;
 }
 
 .type-select {


### PR DESCRIPTION
## Summary
- remove the redundant library header and pin the filter controls to the top of the page with spacing that matches the column gap
- adjust the add-item layout to drop the back link and give the card uniform padding that matches the horizontal gutter

## Testing
- `npm run lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c88885eac8321a6f2ff3423caa772)