### PR TITLE
chore: adds worktree config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ web/.DS_Store
 
 # Local development overrides
 local.mk
+.worktree.json


### PR DESCRIPTION
## Summary
- Ignore .worktree.json so local worktree settings stay untracked