### PR TITLE
Harden shelf layout updates, series payload handling, and CSV export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,6 @@ Anthology is a two-tier catalogue: a Go 1.24 API (under `cmd/api` + `internal/`)
 
 ## Local Auth
 Local dev runs without auth unless OAuth is configured. To exercise OAuth locally, use Postgres plus the Google OAuth env vars and keep `APP_ENV=development` so cookies stay non-secure.
+
+## Workspace Bootstrap
+- If `local.mk` is missing in a new Anthology workspace, copy it from `/Volumes/wd_ssd_2tb/projects/learnd/local.mk` before running `make run` or `make local`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,8 @@ Anthology is a two-tier catalogue: a Go 1.24 API (under `cmd/api` + `internal/`)
 Local dev runs without auth unless OAuth is configured. To exercise OAuth locally, use Postgres plus the Google OAuth env vars and keep `APP_ENV=development` so cookies stay non-secure.
 
 ## Workspace Bootstrap
-- If `local.mk` is missing in a new Anthology workspace, copy it from `/Volumes/wd_ssd_2tb/projects/learnd/local.mk` before running `make run` or `make local`.
+- If `local.mk` is missing in a new workspace/worktree, place a `local.mk` file in the project root before running `make run` or `make local`.
+- Create `local.mk` by either:
+  - copying `local.mk.example`, or
+  - copying `local.mk` from the primary Anthology repo/workspace.
+- If the source `local.mk` location is unclear in a new worktree, ask the user where to copy it from.

--- a/internal/exporter/csv_exporter.go
+++ b/internal/exporter/csv_exporter.go
@@ -104,7 +104,24 @@ func (e *CSVExporter) itemToRow(item items.Item) []string {
 	row[22] = formatTime(item.CreatedAt)
 	row[23] = formatTime(item.UpdatedAt)
 
+	for i := range row {
+		row[i] = sanitizeCSVCell(row[i])
+	}
+
 	return row
+}
+
+func sanitizeCSVCell(value string) string {
+	if value == "" {
+		return value
+	}
+
+	switch value[0] {
+	case '=', '+', '-', '@', '\t':
+		return "'" + value
+	default:
+		return value
+	}
 }
 
 // formatOptionalInt formats an optional integer pointer to a string.

--- a/internal/http/series_handler.go
+++ b/internal/http/series_handler.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -75,8 +74,8 @@ func (h *SeriesHandler) Update(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		NewName string `json:"newName"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeJSONBody(w, r, &body); err != nil {
+		writeJSONError(w, err)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- prevent shelf layout updates from accepting foreign `slotId` values by validating that any client-provided slot ID already belongs to the target shelf
- switch `SeriesHandler.Update` to bounded JSON decoding (`decodeJSONBody`) so payload limits and unknown-field handling are enforced consistently
- mitigate CSV formula injection by prefixing dangerous leading characters in exported cell values
- document workspace bootstrap behavior in `AGENTS.md` for copying `local.mk` when missing

## Security fixes
- **Cross-tenant shelf tampering hardening**: reject layout updates that include a `slotId` not present on the shelf
- **DoS hardening**: enforce max request size for series rename endpoint
- **CSV injection hardening**: neutralize cells beginning with `=`, `+`, `-`, `@`, or tab

## Tests added
- `TestUpdateLayoutRejectsSlotIDFromDifferentShelf`
- `TestSeriesHandlerUpdateRejectsOversizedBody`
- `TestCSVExporter_EscapesFormulaCells`

## Validation
- `go build ./...`
- `go test ./...`
- `make run` smoke test (with temporary OAuth env overrides):
  - migrations applied
  - database connection succeeded
  - API started listening on `:8080`

## Notes
- `local.mk` is intentionally untracked (`.gitignore`) and was copied locally for runtime testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Escaped CSV cells that could be interpreted as formulas to prevent unsafe/misinterpreted exports.
  * Prevented using shelf slots that belong to other shelves when updating layouts.
  * Enforced request size limits to reject oversized API requests (HTTP 413).

* **Documentation**
  * Added workspace bootstrap instructions for local development setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->