### PR TITLE
Center TYPE, YEAR, and UPDATED table columns

### DIFF
--- a/web/src/app/pages/items/items-table-view/items-table-view.component.scss
+++ b/web/src/app/pages/items/items-table-view/items-table-view.component.scss
@@ -66,6 +66,15 @@
     text-overflow: clip;
 }
 
+.items-table th.mat-column-itemType,
+.items-table td.mat-column-itemType,
+.items-table th.mat-column-releaseYear,
+.items-table td.mat-column-releaseYear,
+.items-table th.mat-column-updatedAt,
+.items-table td.mat-column-updatedAt {
+    text-align: center;
+}
+
 .items-table tr:last-child td {
     border-bottom: none;
 }


### PR DESCRIPTION
## Summary
- center header and cell alignment for `itemType`, `releaseYear`, and `updatedAt` columns in items table view
- keep `title` and `creator` columns left-aligned for readability

## Testing
- `cd web && npm run lint`

## Notes
- scoped to CSS in `web/src/app/pages/items/items-table-view/items-table-view.component.scss`
- no auth/config/backend changes