### PR TITLE
chore: add auth state capture tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ web/.DS_Store
 # Local development overrides
 local.mk
 .worktree.json
+.local/
+.auth/
+
+# Local browser automation artifacts
+.playwright-cli/
+output/playwright/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,10 @@ Anthology is a two-tier catalogue: a Go 1.24 API (under `cmd/api` + `internal/`)
 - Backend tests live next to their code (`*_test.go`); cover validation, repository behaviour, importer edge cases, catalog lookups, shelf layout validation, and displacement/placement flows.
 - Frontend specs (`*.spec.ts`) mirror component paths, covering search flow, manual entry, CSV imports, and UI copy.
 - Run `go test ./...`, `npm test -- --watch=false`, and `npm run lint` before every PR. Hook `githooks/pre-commit` into `.git/hooks` to enforce `golangci-lint run ./...` plus `npm run lint` unless `SKIP_PRECOMMIT_LINT=1` is set.
-- Validate UI work in the running Angular app when feasible (for example, if local auth is configured): grab at least one screenshot (include scrolled states if relevant) from `http://localhost:4200`, and log any console or network errors.
+- Validate UI work in the running Angular app when feasible: use Playwright automation by default for navigation/capture, grab at least one screenshot (include scrolled states if relevant) from `http://localhost:4200`, and log any console or network errors.
+- Before running Playwright/browser verification, confirm with the user that the local server is running (`make local`, or API/UI started separately). If not running, ask the user to start it first.
+- If browser automation needs cookies + localStorage (not just the API cookie), prefer capturing Playwright `storageState` via `node scripts/auth-capture.js` and storing it under `./.auth/<appName>.json`.
+  - If the state file is missing/expired, ask the user to run `make auth-capture` (or `node scripts/auth-capture.js`) after logging in manually.
 
 ## Commit & Pull Request Guidelines
 - Keep commits short, imperative, and scoped (e.g., “Add Google OAuth login”). Reference issues in the body when helpful.
@@ -51,3 +54,6 @@ Anthology is a two-tier catalogue: a Go 1.24 API (under `cmd/api` + `internal/`)
 
 ## Local Auth
 Local dev runs without auth unless OAuth is configured. To exercise OAuth locally, use Postgres plus the Google OAuth env vars and keep `APP_ENV=development` so cookies stay non-secure.
+- For local agent/browser verification, do not add auth bypass routes. Reuse a saved Playwright `storageState` captured after manual login:
+  - Capture/refresh: `make auth-capture`
+  - Saved state lives in `./.auth/<appName>.json` (gitignored, treat as secret)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ UI_IMAGE_REPO ?= anthology-ui
 LOG_LEVEL ?= info
 PLATFORMS ?= linux/amd64,linux/arm64/v8
 
-.PHONY: help configure-image ensure-image-tag api-run api-test api-lint api-build api-clean fmt tidy web-install web-start web-test web-lint web-lint-fix web-build lint docker-build docker-build-api docker-build-ui docker-push docker-push-api docker-push-ui docker-publish docker-buildx docker-buildx-api docker-buildx-ui build run local clean
+.PHONY: help configure-image ensure-image-tag api-run api-test api-lint api-build api-clean fmt tidy web-install web-start web-test web-lint web-lint-fix web-build auth-capture lint docker-build docker-build-api docker-build-ui docker-push docker-push-api docker-push-ui docker-publish docker-buildx docker-buildx-api docker-buildx-ui build run local clean
 
 help: ## Show all available targets.
 	@echo "Anthology targets"
@@ -96,6 +96,9 @@ web-lint-fix: ## Run Angular lint checks with auto-fixes and formatting.
 
 web-build: ## Build the Angular production bundle.
 	cd $(WEB_DIR) && npm run build
+
+auth-capture: ## Open a headed browser for manual login, then save Playwright storageState to ./.auth/<appName>.json.
+	node scripts/auth-capture.js
 
 lint: api-lint web-lint ## Run Go and Angular lint checks.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ The dev server runs on `http://localhost:4200` and proxies requests directly to 
 
 You will be redirected to the login screen and asked to continue with Google. The OAuth callback sets an HttpOnly session cookie so the browser stays authenticated; use the “Log out” button in the toolbar to clear it at any time. In `APP_ENV=development`, cookies are non-secure for localhost.
 
+### Capture Auth State (Playwright storageState)
+
+If you want a reusable browser auth state for Playwright-based UI verification (cookies + localStorage), capture a Playwright `storageState` file after manually logging in.
+
+Config file (repo-local):
+- `auth.config.json` (`appName`, `baseURL`, optional `loginURL`)
+
+Capture flow (does not automate login):
+
+```bash
+node scripts/auth-capture.js
+```
+
+This opens a headed Chrome window, navigates to `loginURL` (or `baseURL`), and waits for you to complete login. When you return to the terminal and press Enter, it saves:
+
+- `./.auth/<appName>.json`
+
+Refresh it anytime by re-running the same command (it overwrites the file).
+
+Override config values at runtime (optional):
+
+```bash
+node scripts/auth-capture.js --appName anthology --baseURL http://localhost:4200 --loginURL /login
+```
+
 ### Add items faster
 
 The Add Item page exposes three flows:

--- a/auth.config.json
+++ b/auth.config.json
@@ -1,0 +1,6 @@
+{
+    "appName": "anthology",
+    "baseURL": "http://localhost:4200",
+    "loginURL": "http://localhost:4200/login"
+}
+

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -118,6 +118,23 @@ The application will be available at:
 - Frontend: http://localhost:4200
 - API: http://localhost:8080
 
+## Saved auth state for local agent verification
+
+If you want local agents to verify UI behavior without adding auth bypasses, capture a Playwright `storageState` after you log in manually.
+
+1. Start the app (`make local`) and log in normally in the browser.
+2. Run the capture tool:
+
+```bash
+node scripts/auth-capture.js
+```
+
+This opens a headed browser, waits for you to confirm login (press Enter), and saves:
+
+- `./.auth/<appName>.json`
+
+Refresh it anytime by re-running the same command.
+
 ## OAuth Configuration for Production (anthology.bitofobytes.io)
 
 **Authorized JavaScript origins:**

--- a/scripts/auth-capture.js
+++ b/scripts/auth-capture.js
@@ -6,6 +6,10 @@ const path = require('path');
 const { spawn, spawnSync } = require('child_process');
 const readline = require('readline');
 
+// Pin to a known working version for reproducibility.
+// Override if needed (for example, to test an upgrade): PLAYWRIGHT_CLI_PKG='@playwright/cli@0.1.1'
+const PLAYWRIGHT_CLI_PKG = process.env.PLAYWRIGHT_CLI_PKG || '@playwright/cli@0.1.0';
+
 function parseArgs(argv) {
     const out = {};
     for (let i = 0; i < argv.length; i++) {
@@ -84,7 +88,7 @@ function sanitizeFileStem(value) {
 }
 
 function runPlaywrightCLI(args) {
-    const result = spawnSync('npx', ['--yes', '--package', '@playwright/cli', 'playwright-cli', ...args], {
+    const result = spawnSync('npx', ['--yes', '--package', PLAYWRIGHT_CLI_PKG, 'playwright-cli', ...args], {
         stdio: 'inherit',
         env: process.env,
     });
@@ -96,7 +100,7 @@ function runPlaywrightCLI(args) {
 function openPlaywrightCLI(args) {
     // Launch in the background so we can still read from stdin for the "Press Enter" prompt.
     // We intentionally ignore stdin so the user can interact with this script while the browser is open.
-    const child = spawn('npx', ['--yes', '--package', '@playwright/cli', 'playwright-cli', ...args], {
+    const child = spawn('npx', ['--yes', '--package', PLAYWRIGHT_CLI_PKG, 'playwright-cli', ...args], {
         stdio: ['ignore', 'inherit', 'inherit'],
         env: process.env,
     });

--- a/scripts/auth-capture.js
+++ b/scripts/auth-capture.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const readline = require('readline');
+
+function parseArgs(argv) {
+    const out = {};
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '-h' || arg === '--help') {
+            out.help = true;
+            continue;
+        }
+        if (!arg.startsWith('--')) continue;
+
+        const eq = arg.indexOf('=');
+        if (eq !== -1) {
+            const key = arg.slice(2, eq);
+            const value = arg.slice(eq + 1);
+            out[key] = value;
+            continue;
+        }
+
+        const key = arg.slice(2);
+        const next = argv[i + 1];
+        if (next && !next.startsWith('--')) {
+            out[key] = next;
+            i++;
+        } else {
+            out[key] = true;
+        }
+    }
+    return out;
+}
+
+function printHelp() {
+    console.log(`auth-capture
+
+Open a headed browser, let you log in manually, then save Playwright storageState.
+
+Usage:
+  node scripts/auth-capture.js
+  node scripts/auth-capture.js --config auth.config.json
+  node scripts/auth-capture.js --appName anthology --baseURL http://localhost:4200 --loginURL /login
+
+Writes:
+  ./.auth/<appName>.json
+
+Options:
+  --config <path>     Config file path (default: auth.config.json)
+  --appName <name>    App name (overrides config)
+  --baseURL <url>     Base URL (overrides config)
+  --loginURL <url>    Login URL (optional; overrides config; can be relative)
+  --print-config      Print resolved config and exit
+  -h, --help          Show help
+`);
+}
+
+function readJSON(filePath) {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+}
+
+function isAbsoluteURL(value) {
+    return /^https?:\/\//i.test(value);
+}
+
+function resolveURL(baseURL, maybeURL) {
+    if (!maybeURL) return baseURL;
+    if (isAbsoluteURL(maybeURL)) return maybeURL;
+    return new URL(maybeURL, baseURL).toString();
+}
+
+function sanitizeFileStem(value) {
+    return String(value || '')
+        .trim()
+        .replace(/[^a-zA-Z0-9_-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/(^-|-$)/g, '');
+}
+
+function runPlaywrightCLI(args) {
+    const result = spawnSync('npx', ['--yes', '--package', '@playwright/cli', 'playwright-cli', ...args], {
+        stdio: 'inherit',
+        env: process.env,
+    });
+    if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+    }
+}
+
+async function waitForEnter(prompt) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    await new Promise((resolve) => rl.question(prompt, resolve));
+    rl.close();
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.help) {
+        printHelp();
+        return;
+    }
+
+    const configPath = path.resolve(process.cwd(), String(args.config || 'auth.config.json'));
+    if (!fs.existsSync(configPath)) {
+        console.error(`Missing config file: ${configPath}`);
+        console.error('Create auth.config.json or pass --config <path>.');
+        process.exit(1);
+    }
+
+    const config = readJSON(configPath);
+
+    const appName = String(args.appName || config.appName || '').trim();
+    const baseURL = String(args.baseURL || config.baseURL || '').trim();
+    const loginURL = (args.loginURL !== undefined ? String(args.loginURL) : config.loginURL) || '';
+
+    if (!appName) {
+        console.error('appName is required (set in auth.config.json or pass --appName).');
+        process.exit(1);
+    }
+    if (!baseURL) {
+        console.error('baseURL is required (set in auth.config.json or pass --baseURL).');
+        process.exit(1);
+    }
+
+    const startURL = resolveURL(baseURL, loginURL);
+    const stateDir = path.resolve(process.cwd(), '.auth');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const fileStem = sanitizeFileStem(appName) || 'app';
+    const statePath = path.join(stateDir, `${fileStem}.json`);
+    const sessionName = `auth-${fileStem}`;
+
+    console.log(`Config: ${configPath}`);
+    console.log(`App: ${appName}`);
+    console.log(`Base URL: ${baseURL}`);
+    console.log(`Start URL: ${startURL}`);
+    console.log(`State file: ${statePath}`);
+
+    if (args['print-config']) {
+        return;
+    }
+
+    if (!process.stdin.isTTY) {
+        console.error('This command requires an interactive TTY (it waits for you to press Enter).');
+        console.error('Run it from a normal terminal session (not a non-interactive runner).');
+        process.exit(1);
+    }
+
+    console.log('');
+    console.log('A browser will open in headed mode. Complete login manually.');
+    console.log('When finished, return to this terminal and press Enter to save the authenticated state.');
+    console.log('');
+
+    // Launch headed browser and navigate to start URL.
+    runPlaywrightCLI(['--session', sessionName, 'open', startURL, '--headed', '--browser', 'chrome']);
+
+    await waitForEnter('Press Enter to save storageState (cookies + localStorage) ... ');
+
+    // Save storage state for reuse by agents/tests.
+    runPlaywrightCLI(['--session', sessionName, 'state-save', statePath]);
+
+    // Close the browser session to avoid zombie processes.
+    runPlaywrightCLI(['--session', sessionName, 'close']);
+
+    console.log('');
+    console.log(`Saved: ${statePath}`);
+    console.log('To refresh, re-run this command and overwrite the file.');
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/auth-capture.js
+++ b/scripts/auth-capture.js
@@ -26,7 +26,8 @@ function parseArgs(argv) {
 
         const key = arg.slice(2);
         const next = argv[i + 1];
-        if (next && !next.startsWith('--')) {
+        // Treat empty string ("") as a valid value. Only omit a value when the arg is truly absent.
+        if (next !== undefined && !next.startsWith('--')) {
             out[key] = next;
             i++;
         } else {
@@ -134,9 +135,9 @@ async function main() {
 
     const config = readJSON(configPath);
 
-    const appName = String(args.appName || config.appName || '').trim();
-    const baseURL = String(args.baseURL || config.baseURL || '').trim();
-    const loginURL = (args.loginURL !== undefined ? String(args.loginURL) : config.loginURL) || '';
+    const appName = String((args.appName !== undefined ? args.appName : config.appName) ?? '').trim();
+    const baseURL = String((args.baseURL !== undefined ? args.baseURL : config.baseURL) ?? '').trim();
+    const loginURL = String((args.loginURL !== undefined ? args.loginURL : config.loginURL) ?? '').trim();
 
     if (!appName) {
         console.error('appName is required (set in auth.config.json or pass --appName).');


### PR DESCRIPTION
Adds a repo-local Playwright auth capture flow for manual login and saving `storageState` to `./.auth/<appName>.json`.

Changes:
- `auth.config.json` minimal config for appName/baseURL/loginURL.
- `scripts/auth-capture.js` opens headed Chrome, waits for Enter, saves storageState.
- `make auth-capture` helper target.
- Docs updates in README + LOCAL_DEVELOPMENT + AGENTS.
- Ignore `.auth/` (and Playwright CLI artifacts).

Testing:
- `go test ./...`
- Manual: ran auth capture and verified `state-load` + screenshot via Playwright CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication state capture workflow using Playwright for local UI testing
  * New auth configuration file for managing app-specific settings
  * Make target for automated authentication state capture

* **Documentation**
  * Updated UI validation guides emphasizing Playwright automation
  * New local development documentation for capturing and reusing authentication state
  * Configuration examples and instructions for authentication setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->