### PR TITLE
[codex] Route Goose migration logs through slog

### DIFF
--- a/internal/platform/migrate/goose_logger.go
+++ b/internal/platform/migrate/goose_logger.go
@@ -1,27 +1,123 @@
 package migrate
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pressly/goose/v3"
 )
 
 type gooseSlogLogger struct {
 	logger *slog.Logger
+	exit   func(int)
+}
+
+func newGooseLogger(logger *slog.Logger) goose.Logger {
+	if logger == nil {
+		return goose.NopLogger()
+	}
+
+	return gooseSlogLogger{
+		logger: logger.With("component", "goose"),
+		exit:   os.Exit,
+	}
 }
 
 func (l gooseSlogLogger) Printf(format string, v ...interface{}) {
-	if l.logger == nil {
-		return
-	}
-	msg := fmt.Sprintf(format, v...)
-	l.logger.Info(msg)
+	l.log(slog.LevelInfo, fmt.Sprintf(format, v...))
 }
 
 func (l gooseSlogLogger) Fatalf(format string, v ...interface{}) {
-	msg := fmt.Sprintf(format, v...)
-	if l.logger != nil {
-		l.logger.Error(msg)
+	l.log(slog.LevelError, fmt.Sprintf(format, v...))
+	if l.exit != nil {
+		l.exit(1)
 	}
-	os.Exit(1)
+}
+
+func (l gooseSlogLogger) log(level slog.Level, raw string) {
+	if l.logger == nil {
+		return
+	}
+
+	msg, attrs := structuredGooseLog(raw)
+	l.logger.Log(context.Background(), level, msg, attrs...)
+}
+
+func structuredGooseLog(raw string) (string, []any) {
+	if version, ok := parseGooseVersion(raw, "goose: no migrations to run. current version: "); ok {
+		return "goose migrations up to date", []any{
+			"event", "migration_summary",
+			"status", "up_to_date",
+			"version", version,
+		}
+	}
+
+	if version, ok := parseGooseVersion(raw, "goose: successfully migrated database to version: "); ok {
+		return "goose migrations applied", []any{
+			"event", "migration_summary",
+			"status", "applied",
+			"version", version,
+		}
+	}
+
+	if file, duration, ok := parseGooseStep(raw, "OK   "); ok {
+		return "goose migration step", []any{
+			"event", "migration_step",
+			"result", "ok",
+			"file", file,
+			"duration", duration,
+		}
+	}
+
+	if file, duration, ok := parseGooseStep(raw, "EMPTY "); ok {
+		return "goose migration step", []any{
+			"event", "migration_step",
+			"result", "empty",
+			"file", file,
+			"duration", duration,
+		}
+	}
+
+	return "goose log", []any{
+		"event", "migration_log",
+		"detail", raw,
+	}
+}
+
+func parseGooseVersion(raw string, prefix string) (int64, bool) {
+	value, ok := strings.CutPrefix(raw, prefix)
+	if !ok {
+		return 0, false
+	}
+
+	version, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return version, true
+}
+
+func parseGooseStep(raw string, prefix string) (string, string, bool) {
+	value, ok := strings.CutPrefix(raw, prefix)
+	if !ok {
+		return "", "", false
+	}
+
+	idx := strings.LastIndex(value, " (")
+	if idx <= 0 || !strings.HasSuffix(value, ")") {
+		return "", "", false
+	}
+
+	file := value[:idx]
+	duration := strings.TrimSuffix(value[idx+2:], ")")
+	if file == "" || duration == "" {
+		return "", "", false
+	}
+
+	return file, duration, true
 }

--- a/internal/platform/migrate/goose_logger.go
+++ b/internal/platform/migrate/goose_logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,12 @@ type gooseSlogLogger struct {
 	logger *slog.Logger
 	exit   func(int)
 }
+
+var (
+	gooseNoMigrationsPattern = regexp.MustCompile(`^goose:\s+no migrations to run\.\s+current version:\s+(\d+)$`)
+	gooseMigratedPattern     = regexp.MustCompile(`^goose:\s+successfully migrated database to version:\s+(\d+)$`)
+	gooseStepPattern         = regexp.MustCompile(`^(OK|EMPTY)\s+(.+)\s+\(([^()]+)\)$`)
+)
 
 func newGooseLogger(logger *slog.Logger) goose.Logger {
 	if logger == nil {
@@ -48,7 +55,7 @@ func (l gooseSlogLogger) log(level slog.Level, raw string) {
 }
 
 func structuredGooseLog(raw string) (string, []any) {
-	if version, ok := parseGooseVersion(raw, "goose: no migrations to run. current version: "); ok {
+	if version, ok := parseGooseVersion(raw, gooseNoMigrationsPattern); ok {
 		return "goose migrations up to date", []any{
 			"event", "migration_summary",
 			"status", "up_to_date",
@@ -56,7 +63,7 @@ func structuredGooseLog(raw string) (string, []any) {
 		}
 	}
 
-	if version, ok := parseGooseVersion(raw, "goose: successfully migrated database to version: "); ok {
+	if version, ok := parseGooseVersion(raw, gooseMigratedPattern); ok {
 		return "goose migrations applied", []any{
 			"event", "migration_summary",
 			"status", "applied",
@@ -64,19 +71,10 @@ func structuredGooseLog(raw string) (string, []any) {
 		}
 	}
 
-	if file, duration, ok := parseGooseStep(raw, "OK   "); ok {
+	if result, file, duration, ok := parseGooseStep(raw); ok {
 		return "goose migration step", []any{
 			"event", "migration_step",
-			"result", "ok",
-			"file", file,
-			"duration", duration,
-		}
-	}
-
-	if file, duration, ok := parseGooseStep(raw, "EMPTY "); ok {
-		return "goose migration step", []any{
-			"event", "migration_step",
-			"result", "empty",
+			"result", result,
 			"file", file,
 			"duration", duration,
 		}
@@ -88,13 +86,13 @@ func structuredGooseLog(raw string) (string, []any) {
 	}
 }
 
-func parseGooseVersion(raw string, prefix string) (int64, bool) {
-	value, ok := strings.CutPrefix(raw, prefix)
-	if !ok {
+func parseGooseVersion(raw string, pattern *regexp.Regexp) (int64, bool) {
+	matches := pattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if len(matches) != 2 {
 		return 0, false
 	}
 
-	version, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	version, err := strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {
 		return 0, false
 	}
@@ -102,22 +100,18 @@ func parseGooseVersion(raw string, prefix string) (int64, bool) {
 	return version, true
 }
 
-func parseGooseStep(raw string, prefix string) (string, string, bool) {
-	value, ok := strings.CutPrefix(raw, prefix)
-	if !ok {
-		return "", "", false
+func parseGooseStep(raw string) (string, string, string, bool) {
+	matches := gooseStepPattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if len(matches) != 4 {
+		return "", "", "", false
 	}
 
-	idx := strings.LastIndex(value, " (")
-	if idx <= 0 || !strings.HasSuffix(value, ")") {
-		return "", "", false
-	}
-
-	file := value[:idx]
-	duration := strings.TrimSuffix(value[idx+2:], ")")
+	result := strings.ToLower(matches[1])
+	file := strings.TrimSpace(matches[2])
+	duration := strings.TrimSpace(matches[3])
 	if file == "" || duration == "" {
-		return "", "", false
+		return "", "", "", false
 	}
 
-	return file, duration, true
+	return result, file, duration, true
 }

--- a/internal/platform/migrate/goose_logger_test.go
+++ b/internal/platform/migrate/goose_logger_test.go
@@ -1,0 +1,125 @@
+package migrate
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestNewGooseLoggerFormatsMigrationSummary(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	adapter, ok := newGooseLogger(logger).(gooseSlogLogger)
+	if !ok {
+		t.Fatal("expected goose slog logger adapter")
+	}
+
+	adapter.Printf("goose: successfully migrated database to version: %d", 7)
+
+	record := decodeLogRecord(t, &buf)
+	if got := record["msg"]; got != "goose migrations applied" {
+		t.Fatalf("unexpected log message: got %v", got)
+	}
+	if got := record["component"]; got != "goose" {
+		t.Fatalf("unexpected component: got %v", got)
+	}
+	if got := record["event"]; got != "migration_summary" {
+		t.Fatalf("unexpected event: got %v", got)
+	}
+	if got := record["status"]; got != "applied" {
+		t.Fatalf("unexpected status: got %v", got)
+	}
+	if got := record["version"]; got != float64(7) {
+		t.Fatalf("unexpected version: got %v", got)
+	}
+}
+
+func TestNewGooseLoggerFormatsMigrationStep(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	adapter, ok := newGooseLogger(logger).(gooseSlogLogger)
+	if !ok {
+		t.Fatal("expected goose slog logger adapter")
+	}
+
+	adapter.Printf("OK   %s (%s)", "0002_add_shelves.sql", "12.4ms")
+
+	record := decodeLogRecord(t, &buf)
+	if got := record["msg"]; got != "goose migration step" {
+		t.Fatalf("unexpected log message: got %v", got)
+	}
+	if got := record["event"]; got != "migration_step" {
+		t.Fatalf("unexpected event: got %v", got)
+	}
+	if got := record["result"]; got != "ok" {
+		t.Fatalf("unexpected result: got %v", got)
+	}
+	if got := record["file"]; got != "0002_add_shelves.sql" {
+		t.Fatalf("unexpected file: got %v", got)
+	}
+	if got := record["duration"]; got != "12.4ms" {
+		t.Fatalf("unexpected duration: got %v", got)
+	}
+}
+
+func TestGooseSlogLoggerFatalfLogsAndExits(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	exitCode := 0
+	adapter := gooseSlogLogger{
+		logger: logger.With("component", "goose"),
+		exit: func(code int) {
+			exitCode = code
+		},
+	}
+
+	adapter.Fatalf("goose: failed to apply version %d", 5)
+
+	if exitCode != 1 {
+		t.Fatalf("unexpected exit code: got %d", exitCode)
+	}
+
+	record := decodeLogRecord(t, &buf)
+	if got := record["level"]; got != "ERROR" {
+		t.Fatalf("unexpected log level: got %v", got)
+	}
+	if got := record["msg"]; got != "goose log" {
+		t.Fatalf("unexpected log message: got %v", got)
+	}
+	if got := record["detail"]; got != "goose: failed to apply version 5" {
+		t.Fatalf("unexpected log detail: got %v", got)
+	}
+}
+
+func TestNewGooseLoggerNilReturnsSilentLogger(t *testing.T) {
+	t.Parallel()
+
+	logger := newGooseLogger(nil)
+	if logger == nil {
+		t.Fatal("expected non-nil goose logger")
+	}
+
+	logger.Printf("should not panic")
+	logger.Fatalf("should not exit")
+}
+
+func decodeLogRecord(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	var record map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &record); err != nil {
+		t.Fatalf("failed to decode log record: %v", err)
+	}
+
+	return record
+}

--- a/internal/platform/migrate/goose_logger_test.go
+++ b/internal/platform/migrate/goose_logger_test.go
@@ -38,6 +38,34 @@ func TestNewGooseLoggerFormatsMigrationSummary(t *testing.T) {
 	}
 }
 
+func TestNewGooseLoggerFormatsUpToDateSummaryWithNewline(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	adapter, ok := newGooseLogger(logger).(gooseSlogLogger)
+	if !ok {
+		t.Fatal("expected goose slog logger adapter")
+	}
+
+	adapter.Printf("goose: no migrations to run.\ncurrent version: %d", 7)
+
+	record := decodeLogRecord(t, &buf)
+	if got := record["msg"]; got != "goose migrations up to date" {
+		t.Fatalf("unexpected log message: got %v", got)
+	}
+	if got := record["event"]; got != "migration_summary" {
+		t.Fatalf("unexpected event: got %v", got)
+	}
+	if got := record["status"]; got != "up_to_date" {
+		t.Fatalf("unexpected status: got %v", got)
+	}
+	if got := record["version"]; got != float64(7) {
+		t.Fatalf("unexpected version: got %v", got)
+	}
+}
+
 func TestNewGooseLoggerFormatsMigrationStep(t *testing.T) {
 	t.Parallel()
 
@@ -50,6 +78,37 @@ func TestNewGooseLoggerFormatsMigrationStep(t *testing.T) {
 	}
 
 	adapter.Printf("OK   %s (%s)", "0002_add_shelves.sql", "12.4ms")
+
+	record := decodeLogRecord(t, &buf)
+	if got := record["msg"]; got != "goose migration step" {
+		t.Fatalf("unexpected log message: got %v", got)
+	}
+	if got := record["event"]; got != "migration_step" {
+		t.Fatalf("unexpected event: got %v", got)
+	}
+	if got := record["result"]; got != "ok" {
+		t.Fatalf("unexpected result: got %v", got)
+	}
+	if got := record["file"]; got != "0002_add_shelves.sql" {
+		t.Fatalf("unexpected file: got %v", got)
+	}
+	if got := record["duration"]; got != "12.4ms" {
+		t.Fatalf("unexpected duration: got %v", got)
+	}
+}
+
+func TestNewGooseLoggerFormatsMigrationStepWithSingleSpaceAndNewline(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	adapter, ok := newGooseLogger(logger).(gooseSlogLogger)
+	if !ok {
+		t.Fatal("expected goose slog logger adapter")
+	}
+
+	adapter.Printf("OK %s (%s)\n", "0002_add_shelves.sql", "12.4ms")
 
 	record := decodeLogRecord(t, &buf)
 	if got := record["msg"]; got != "goose migration step" {

--- a/internal/platform/migrate/migrate.go
+++ b/internal/platform/migrate/migrate.go
@@ -21,9 +21,7 @@ const (
 // Apply runs any pending SQL migrations bundled with the binary.
 func Apply(ctx context.Context, db *sqlx.DB, logger *slog.Logger) error {
 	goose.SetBaseFS(migrations.Files)
-	if logger != nil {
-		goose.SetLogger(gooseSlogLogger{logger: logger.With("component", "goose")})
-	}
+	goose.SetLogger(newGooseLogger(logger))
 	if err := goose.SetDialect("postgres"); err != nil {
 		return fmt.Errorf("migrate: set goose dialect: %w", err)
 	}


### PR DESCRIPTION
## Summary

Goose migration logging was already partially wired into the API startup logger, but the adapter only forwarded raw formatted strings and had no coverage. That left migration output less consistent than the rest of the startup path and made it easy for future changes to drift back toward unstructured logging.

This change routes Goose through a dedicated adapter constructor in the migration package, keeps the migration logs on the apps `slog` path, and upgrades common Goose messages into structured records. Startup migration summaries now carry fields such as `event`, `status`, and `version`, and per-migration step logs include the migration file and duration. The adapters fatal path is also injectable so the behavior can be tested without terminating the test process.

## Validation

- `go test ./internal/platform/migrate`
- `go test ./...`
