### PR TITLE
docs: add concise public self-hosting guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 bin/
 *.log
 coverage.out
+anthology.env
 
 web/node_modules/
 web/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ web/.DS_Store
 
 # Local development overrides
 local.mk
+anthology.env
 .worktree.json
 .local/
 .auth/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,76 +1,8 @@
-# Repository Guidelines
+# Agent Guidance
 
-## Stack overview
-Anthology is a two-tier catalogue: a Go 1.26.4 API (under `cmd/api` + `internal/`) fronted by an Angular 21 Material UI (`web/`). Recent work adds metadata search (Google Books), CSV imports, and cover thumbnails that all flow through the Add Item page so validation and enrichment behave consistently. A new shelves module models real-world shelves with photo-backed layouts so items can be placed into slots and surfaced in the UI.
-
-## Project Structure & Module Organization
-- `cmd/api`: Go entrypoint; wire up config, repositories, chi router, middleware, and HTTP handlers.
-- `internal/`: shared Go packages (domain logic, importer, catalog lookups, services, transport, config). Shelf layout + placement logic now lives in `internal/shelves`.
-- `migrations/`: Postgres DDL managed by Goose. `0001_baseline.sql` captures the current schema.
-- `web/`: Angular workspace (feature modules under `web/src/app`, Material theme in `web/src/styles.scss`, runtime config in `web/src/assets/runtime-config.js`). Shelf management views live under `web/src/app/pages/shelves`.
-- `Docker/`: split Dockerfiles (`Dockerfile.api`, `Dockerfile.ui`) for the independently deployable API/UI containers.
-- `docs/architecture/` & `docs/planning/`: architecture diagrams, startup flows, Material guidelines, and roadmap notes.
-
-## Build, Test, and Development Commands
-- `make api-run` (or `make run`) — boots the API using `local.mk`/current env vars; requires Postgres (`DATA_STORE=postgres` + `DATABASE_URL`) and applies Goose migrations on startup.
-- `make api-test` — Go unit tests (catalog lookups, importer, services, handlers); equivalent to `go test ./...`.
-- `make api-lint`, `make fmt`, and `make tidy` — run `golangci-lint`, format Go sources, and tidy modules.
-- `make api-build` and `make api-clean` — compile the Go API into `bin/anthology` or remove compiled Go binaries.
-- `make web-install` — install Angular deps under `web/`.
-- `make web-start` — Angular dev server on `http://localhost:4200` proxying to the API URL defined in the meta tag/runtime config.
-- `make web-test`, `make web-lint`, and `make web-lint-fix` — Vitest unit tests, lint/style/format checks, and the auto-fix variant.
-- `make web-build` — build the Angular production bundle.
-- `make auth-capture` — open a headed browser for manual login and save Playwright `storageState` under `./.auth/<appName>.json`; configure `auth.config.json` first or pass equivalent script arguments.
-- `make lint` — run both Go and Angular lint checks.
-- `make local` — convenience target to boot the API and Angular dev server together for end-to-end checks.
-- `make build` — run API tests and web tests, then build both container images.
-- `make docker-build`, `make docker-push`, and `make docker-publish` — build, push, or build-and-push both API/UI images with the Makefile defaults.
-- `make docker-buildx` — build and push multi-arch API/UI images; set registry/tag inputs locally or in CI.
-- `make clean` — remove local Go build artifacts.
-
-## Coding Style & Naming Conventions
-- Go: auto-format with `gofmt`, keep imports sorted, use short receiver names, and follow package boundaries like `internal/items`. Exported types mirror the `ItemService`/`ItemRepository` style. Logging uses `slog`.
-- Angular: 2-space indentation, kebab-case filenames (`items-page.component.ts`), standalone components, and SCSS scoped per component. Stick to Material 3 tokens defined in `styles.scss`. Keep environment variables in screaming snake case (e.g., `GOOGLE_BOOKS_API_KEY`).
-
-## Configuration & Security
-- Primary env vars: `DATA_STORE`, `DATABASE_URL`, `PORT`, `LOG_LEVEL`, `ALLOWED_ORIGINS`, `APP_ENV`, `GOOGLE_BOOKS_API_KEY`, `AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_GOOGLE_REDIRECT_URL`, `AUTH_GOOGLE_ALLOWED_DOMAINS`, `AUTH_GOOGLE_ALLOWED_EMAILS`, `FRONTEND_URL`. `_FILE` variants are respected (defaults point to `/run/secrets/anthology_*`, including `anthology_google_books_api_key`, `anthology_google_client_id`, and `anthology_google_client_secret`). `GOOGLE_BOOKS_API_KEY` is required even in local/dev; set a placeholder when testing.
-- The in-memory store has been removed; `DATA_STORE=postgres` is required and expects Goose migrations to be applied (uses the `sqlx` repo implementation).
-- CORS defaults allow `http://localhost:4200`/`8080`; override via `ALLOWED_ORIGINS`.
-- OAuth is required in all environments (configure Google OAuth client ID/secret plus an allowlist) and relies on Postgres for sessions.
-- Never commit secrets; rely on `.env` files locally. Docker secrets include `anthology_database_url`, `anthology_google_books_api_key`, `anthology_google_client_id`, and `anthology_google_client_secret`, which map to the `_FILE` envs.
-
-## Feature behavior notes
-- Reading status supports `none`/`want_to_read`/`reading`/`read`; defaults to `none`. Filtering by `status` with no type filter applies only to books (non-books remain visible when status = `none`, and are excluded for the other statuses). `read` requires `readAt`; `reading` enforces non-negative `currentPage` capped by `pageCount` when provided.
-- Shelf APIs (`/api/shelves`) expose list/create/get, layout updates, and slot assignment/removal. Layout updates return displaced items; item placements update the cached `shelfPlacement` on items for list/grid views.
-
-## Testing & Validation Guidelines
-- Backend tests live next to their code (`*_test.go`); cover validation, repository behaviour, importer edge cases, catalog lookups, shelf layout validation, and displacement/placement flows.
-- Frontend specs (`*.spec.ts`) mirror component paths, covering search flow, manual entry, CSV imports, and UI copy.
-- Run `make api-test`, `make web-test`, and `make lint` before every PR. Hook `githooks/pre-commit` into `.git/hooks` to enforce `golangci-lint run ./...` plus `npm run lint` unless `SKIP_PRECOMMIT_LINT=1` is set.
-- Validate UI work in the running Angular app when feasible: use Playwright automation by default for navigation/capture, grab at least one screenshot (include scrolled states if relevant) from `http://localhost:4200`, and log any console or network errors.
-- Before running Playwright/browser verification, confirm with the user that the local server is running (`make local`, or API/UI started separately). If not running, ask the user to start it first.
-- If browser automation needs cookies + localStorage (not just the API cookie), prefer capturing Playwright `storageState` via `node scripts/auth-capture.js` and storing it under `./.auth/<appName>.json`.
-  - If the state file is missing/expired, ask the user to run `make auth-capture` (or `node scripts/auth-capture.js`) after logging in manually.
-
-## Commit & Pull Request Guidelines
-- Keep commits short, imperative, and scoped (e.g., “Add Google OAuth login”). Reference issues in the body when helpful.
-- PRs must include a change summary, manual test notes, confirmation that `make api-test`, `make web-test`, and `make lint` were run, and screenshots or GIFs for UI changes. Mention deployment/migration steps if applicable.
-
-## Deployment Notes
-- Docker images are split: API (`Docker/Dockerfile.api`) and UI (`Docker/Dockerfile.ui`). Makefile targets (`docker-build-*`, `docker-push-*`, `docker-buildx-*`) wrap builds/pushes.
-- The UI container's `Docker/ui/nginx.conf` intentionally serves the SPA shell only for allowlisted direct paths, plus explicit redirects and path aliases such as `/items`, then returns 404 for unknown paths; when changing routes, compare it with `web/src/app/app.routes.ts` and verify any extra nginx entries are deliberate.
-- UI container rewrites `assets/runtime-config.js` from `NG_APP_API_URL` at startup so you can repoint environments without rebuilding Angular assets.
-- Apply Goose migrations before booting the Postgres-backed API (or let the API run them on startup), and ensure services load secrets through env vars or Swarm/Stack secret mounts.
-
-## Local Auth
-Local dev runs without auth unless OAuth is configured. To exercise OAuth locally, use Postgres plus the Google OAuth env vars and keep `APP_ENV=development` so cookies stay non-secure.
-- For local agent/browser verification, do not add auth bypass routes. Reuse a saved Playwright `storageState` captured after manual login:
-  - Capture/refresh: `make auth-capture`
-  - Saved state lives in `./.auth/<appName>.json` (gitignored, treat as secret)
-
-## Workspace Bootstrap
-- If `local.mk` is missing in a new workspace/worktree, place a `local.mk` file in the project root before running `make run` or `make local`.
-- Create `local.mk` by either:
-  - copying `local.mk.example`, or
-  - copying `local.mk` from the primary Anthology repo/workspace.
-- If the source `local.mk` location is unclear in a new worktree, ask the user where to copy it from.
+- Treat `web/src/assets/runtime-config.js` as runtime configuration: the UI container rewrites it from `NG_APP_API_URL` without rebuilding the Angular bundle.
+- Keep API and UI deployment concerns separate; the project intentionally publishes two images.
+- Do not add authentication bypass routes. For browser verification, reuse manually captured Playwright state under the ignored `.auth/` directory and never commit it.
+- Update source files rather than generated Angular build output under `web/dist/`.
+- Run both Go and Angular tests for cross-tier changes. UI changes should also pass lint and receive browser verification when the application is available.
+- Preserve the startup migration path: the API applies embedded Goose migrations before serving requests.

--- a/README.md
+++ b/README.md
@@ -1,267 +1,114 @@
 # Anthology
 
-Anthology is a two-tier catalogue that combines a Go API (powered by the [`chi`](https://github.com/go-chi/chi) router) with an Angular Material frontend. The API and UI now ship as independently deployable services, making it easy to scale or update either tier without rebuilding the other. The Phase 1 MVP focuses on managing a personal library of books, games, movies, and music with a polished catalogue presentation.
+Anthology is a self-hosted catalogue for books, games, movies, and music. It pairs a Go API with an Angular frontend and includes metadata search, CSV import, cover images, and visual shelf layouts.
 
-Recent feature work adds a metadata search workflow (backed by Google Books) plus CSV import so large collections can be ingested in one shot. Additionally, a new Shelves module allows you to model physical shelves with photo-backed layouts and place items into specific slots using a drag-and-drop editor.
+## Requirements
 
-If you are new to the project, start with [`docs/architecture/overview.md`](docs/architecture/overview.md). It diagrams the high-level layout (Go API, Angular UI, database, and Google Books) and calls out where CSV uploads and search lookups plug into the stack.
+- Docker 24+
+- PostgreSQL 15+
+- A Google Cloud project with:
+  - [Google Books API](https://developers.google.com/books/docs/v1/using) enabled and an API key
+  - An [OAuth 2.0 Web application client](https://developers.google.com/identity/protocols/oauth2/web-server)
 
-## Project structure
+For local OAuth, add this exact authorized redirect URI to the Google client:
 
-```
-├── cmd/api                       # Go entrypoint
-├── internal                      # Go packages (config, HTTP transport, domain logic, shelves)
-├── migrations                    # SQL migrations for Postgres
-├── web                           # Angular workspace (standalone application)
-├── Docker/Dockerfile.api         # Go API container definition
-├── Docker/Dockerfile.ui          # Static Angular UI container (nginx)
-└── docs/planning/anthology.md
+```text
+http://localhost:8080/api/auth/google/callback
 ```
 
-## Backend (Go)
+Production callbacks must use HTTPS and exactly match `AUTH_GOOGLE_REDIRECT_URL`. Configure at least one allowed email address or domain so the application knows who may sign in.
 
-* Go 1.26 with structured logging via `log/slog`.
-* HTTP routing handled by `chi`, with middleware for request IDs, timeouts, and structured logging.
-* Postgres repositories in `internal/items` and `internal/shelves` handle persistence, shelf layouts, and item placement.
-* Metadata lookups (`internal/catalog`) call the Google Books API. `/api/catalog/lookup` proxies those queries so the Angular UI can search by ISBN or keyword without exposing API tokens.
-* Bulk imports use `internal/importer`, which accepts CSV uploads, fetches metadata for incomplete rows, deduplicates based on title/ISBN, and returns a structured summary so the UI can visualize success vs. warnings.
-* Configuration is environment-driven (`DATA_STORE`, `DATABASE_URL`, `PORT`, `LOG_LEVEL`, `ALLOWED_ORIGINS`, `APP_ENV`, `GOOGLE_BOOKS_API_KEY`, `AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_GOOGLE_REDIRECT_URL`, `AUTH_GOOGLE_ALLOWED_DOMAINS`, `AUTH_GOOGLE_ALLOWED_EMAILS`, `FRONTEND_URL`). Postgres is required (`DATA_STORE=postgres`). Secrets can be provided via environment variables, `<NAME>_FILE` pointers, or the default Docker Swarm secret paths under `/run/secrets/anthology_*`.
-* Google OAuth is required in all environments (configure the Google client ID/secret plus an allowlist). OAuth sessions are stored in Postgres, so deployments must use `DATA_STORE=postgres`.
-* In `APP_ENV=development`, cookies are non-secure for localhost; `/health` remains public in all environments.
-* CORS is enabled via [`github.com/go-chi/cors`](https://github.com/go-chi/cors) and defaults to allowing `http://localhost:4200` and `http://localhost:8080`. Override with `ALLOWED_ORIGINS="https://example.com,https://admin.example.com"` when deploying.
-* Postgres persistence is implemented with `sqlx`; migrations are managed by Goose with a baseline in `migrations/0001_baseline.sql` and tracked in `goose_db_version`.
+## Build the images
 
-### Running the API locally (Postgres)
+From the repository root:
 
 ```bash
-# From the repository root
-export DATA_STORE=postgres
-export DATABASE_URL="postgres://anthology:anthology@localhost:5432/anthology?sslmode=disable"
-export PORT=8080
-export ALLOWED_ORIGINS="http://localhost:4200,http://localhost:8080"
-export APP_ENV=development
-export GOOGLE_BOOKS_API_KEY="super-google-books-key"
-go run ./cmd/api
+docker build -f Docker/Dockerfile.api -t anthology-api:local .
+docker build -f Docker/Dockerfile.ui -t anthology-ui:local .
 ```
 
-OAuth is required in development. Use Postgres and set `AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`, and either `AUTH_GOOGLE_ALLOWED_DOMAINS` or `AUTH_GOOGLE_ALLOWED_EMAILS` (keep `APP_ENV=development` so cookies remain non-secure for localhost).
+## Configure the API
 
-The API listens on `http://localhost:8080` and exposes JSON-only endpoints (the Angular bundle is served by the separate UI container):
+Create an untracked `anthology.env` file:
 
-| Method | Endpoint       | Description            |
-| ------ | -------------- | ---------------------- |
-| GET    | `/health`      | Service health check   |
-| GET    | `/api/auth/google` | Start the Google OAuth flow (redirect) |
-| GET    | `/api/auth/google/callback` | OAuth callback; sets session cookie |
-| GET    | `/api/session` | Return active session status |
-| DELETE | `/api/session` | Clear the session cookie |
-| GET    | `/api/session/user` | Return the current user (authenticated only) |
-| GET    | `/api/items`   | List catalogue items   |
-| POST   | `/api/items`   | Create a new item      |
-| POST   | `/api/items/import` | Upload a CSV file and import multiple items |
-| GET    | `/api/items/{id}` | Retrieve an item   |
-| PUT    | `/api/items/{id}` | Update an item      |
-| DELETE | `/api/items/{id}` | Delete an item      |
+```dotenv
+APP_ENV=development
+DATABASE_URL=postgres://anthology:change-me@db:5432/anthology?sslmode=disable
+GOOGLE_BOOKS_API_KEY=replace-with-your-api-key
+AUTH_GOOGLE_CLIENT_ID=replace-with-your-client-id.apps.googleusercontent.com
+AUTH_GOOGLE_CLIENT_SECRET=replace-with-your-client-secret
+AUTH_GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/google/callback
+AUTH_GOOGLE_ALLOWED_EMAILS=you@example.com
+FRONTEND_URL=http://localhost:4200
+ALLOWED_ORIGINS=http://localhost:4200
+```
 
-### Using Postgres
+Do not commit this file. `AUTH_GOOGLE_ALLOWED_DOMAINS` can replace or supplement `AUTH_GOOGLE_ALLOWED_EMAILS` with a comma-separated domain list.
 
-OAuth requires Postgres. Configure the Google OAuth env vars and allowlist in all environments.
+| Setting | Required | Purpose |
+| --- | --- | --- |
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `GOOGLE_BOOKS_API_KEY` | Yes | Google Books metadata lookup |
+| `AUTH_GOOGLE_CLIENT_ID` | Yes | Google OAuth client ID |
+| `AUTH_GOOGLE_CLIENT_SECRET` | Yes | Google OAuth client secret |
+| `AUTH_GOOGLE_ALLOWED_EMAILS` or `AUTH_GOOGLE_ALLOWED_DOMAINS` | Yes | Login allowlist |
+| `AUTH_GOOGLE_REDIRECT_URL` | No | OAuth callback; defaults to the local URL above |
+| `FRONTEND_URL` | No | Redirect target after authentication |
+| `ALLOWED_ORIGINS` | No | Comma-separated browser origins allowed by CORS |
+| `APP_ENV` | No | `development` or `production`; defaults to `production` |
+| `PORT` | No | API port; defaults to `8080` |
+| `LOG_LEVEL` | No | Application log level; defaults to `info` |
+
+The four secret values also support matching `*_FILE` variables. The image defaults to files under `/run/secrets/anthology_*`, making Docker or Kubernetes secret mounts usable without placing credentials in environment variables.
+
+## Run with Docker
+
+Start PostgreSQL and both application containers on a private Docker network:
 
 ```bash
-export DATA_STORE=postgres
-export DATABASE_URL="postgres://anthology:anthology@localhost:5432/anthology?sslmode=disable"
-export PORT=8080
-export ALLOWED_ORIGINS="https://tracker.example.com"
-export APP_ENV=production
-export AUTH_GOOGLE_CLIENT_ID="google-client-id"
-export AUTH_GOOGLE_CLIENT_SECRET="google-client-secret"
-export AUTH_GOOGLE_ALLOWED_DOMAINS="example.com"
-export AUTH_GOOGLE_REDIRECT_URL="https://app.example.com/api/auth/google/callback"
-export FRONTEND_URL="https://app.example.com"
-export GOOGLE_BOOKS_API_KEY="prod-google-books-key"
+docker network create anthology
 
-# Apply migrations (API startup runs this automatically)
-goose -dir migrations postgres "$DATABASE_URL" up
+docker run -d --name db --network anthology \
+  -e POSTGRES_DB=anthology \
+  -e POSTGRES_USER=anthology \
+  -e POSTGRES_PASSWORD=change-me \
+  -v anthology-postgres:/var/lib/postgresql/data \
+  postgres:17
 
-go run ./cmd/api
+docker run -d --name anthology-api --network anthology \
+  --env-file anthology.env \
+  -p 8080:8080 \
+  anthology-api:local
+
+docker run -d --name anthology-ui --network anthology \
+  -e NG_APP_API_URL=http://localhost:8080/api \
+  -p 4200:80 \
+  anthology-ui:local
 ```
 
-### Tests
+Open <http://localhost:4200>. The API applies embedded Goose migrations automatically during startup. Its public health check is available at <http://localhost:8080/health>.
+
+For production, use HTTPS, set `APP_ENV=production`, use a strong database password, restrict the Google API key, and provide secrets through your platform's secret manager.
+
+## Development
+
+Copy `local.mk.example` to the ignored `local.mk`, fill in the required values, and run both services:
 
 ```bash
-go test ./...
+make web-install
+make local
 ```
 
-The Go test suite covers the metadata lookup pipeline (`internal/catalog`) and the CSV importer end-to-end (`internal/importer`, `internal/http/handlers`).
-
-## Frontend (Angular)
-
-* Angular 21 standalone application located in `web/`.
-* Styling is powered by [`@angular/material`](https://www.npmjs.com/package/@angular/material) and its Material 3 design tokens. The global theme lives in [`web/src/styles.scss`](web/src/styles.scss).
-* The main page (`ItemsPageComponent`) provides a responsive catalogue view, inline editing, and CRUD actions that call the Go API. A dedicated login screen initiates Google OAuth and relies on an HttpOnly session cookie so browsers send it automatically without exposing it to JavaScript.
-* API base URL is resolved from the `<meta name="anthology-api">` tag (defaults to `http://localhost:8080/api`).
-  Deployments can override this without rebuilding by setting `window.NG_APP_API_URL` before the Angular bundle loads (the shipped `assets/runtime-config.js` file is replaced at container start when `NG_APP_API_URL` is defined).
-* The UI seed data and layout offer a curated catalogue dashboard out of the box.
-
-### Development workflow
+Useful checks:
 
 ```bash
-cd web
-npm install
-npm start                           # ng serve --open
+make api-test
+make web-test
+make lint
 ```
 
-The dev server runs on `http://localhost:4200` and proxies requests directly to the API URL specified in the meta tag. To point at a different backend, update the meta tag in `web/src/index.html` or adjust `web/src/assets/runtime-config.js` before serving. Running `make local` will start both the Go API and Angular dev server together for local testing so you can exercise the split-stack workflow end-to-end.
+Frontend-specific development notes live in [`web/README.md`](web/README.md). Architecture documentation is under [`docs/architecture`](docs/architecture).
 
-You will be redirected to the login screen and asked to continue with Google. The OAuth callback sets an HttpOnly session cookie so the browser stays authenticated; use the “Log out” button in the toolbar to clear it at any time. In `APP_ENV=development`, cookies are non-secure for localhost.
+## License
 
-### Capture Auth State (Playwright storageState)
-
-If you want a reusable browser auth state for Playwright-based UI verification (cookies + localStorage), capture a Playwright `storageState` file after manually logging in.
-
-Config file (repo-local):
-- `auth.config.json` (`appName`, `baseURL`, optional `loginURL`)
-
-Capture flow (does not automate login):
-
-```bash
-node scripts/auth-capture.js
-```
-
-This opens a headed Chrome window, navigates to `loginURL` (or `baseURL`), and waits for you to complete login. When you return to the terminal and press Enter, it saves:
-
-- `./.auth/<appName>.json`
-
-Refresh it anytime by re-running the same command (it overwrites the file).
-
-Override config values at runtime (optional):
-
-```bash
-node scripts/auth-capture.js --appName anthology --baseURL http://localhost:4200 --loginURL /login
-```
-
-### Add items faster
-
-The Add Item page exposes three flows:
-
-1. **Search** — pick a category (books, games, movies, or music) and search by keyword or ISBN/identifier. Successful lookups populate the manual entry tab with the retrieved metadata and also allow one-click adds straight to the collection. Errors and empty results stay on the Search tab so you can refine queries.
-2. **Manual entry** — edit all item fields directly. If you switch to this tab from the Search experience, a badge explains which query populated the form to help trace provenance.
-3. **CSV import** — upload a CSV file using the template linked on the page. The UI shows the active status (`Uploading`, `Imported n of m rows`, or `Warnings/Errors`) along with a summary of duplicate or invalid rows.
-
-Use the provided [`web/public/csv-import-template.csv`](web/public/csv-import-template.csv) as a starting point. Every column is optional except for `title` and `itemType`, and missing metadata will be backfilled during the import if ISBN data is present.
-
-### Shelves and visual layouts
-
-You can now model physical shelves in the application. Create a shelf, upload a photo of it, and use the visual editor to define "slots" where items can be placed. The editor supports:
-
-* **Drag-and-drop sizing**: Draw and resize slots directly on the shelf photo.
-* **Axis locking**: Hold shift or drag deliberately along an axis to lock movement to X or Y coordinates for precise alignment.
-* **Item placement**: Assign items from your catalogue to specific slots, tracking exactly where each physical copy resides.
-
-### Cover thumbnails and gallery view
-
-Books can now carry a `coverImage` that powers the grid (thumbnail) view on the library page. Covers accept either:
-
-* A remote URL (preferred for durability and cacheability, e.g., the Open Library cover service used during ISBN lookups and CSV enrichment).
-* A small data URI (JPG/PNG) for user uploads, capped at 500KB to keep API payloads and database storage manageable.
-
-Use the new cover controls on the Add/Edit forms to upload a thumbnail or paste a URL. When browsing your library, switch between the traditional table and the new card grid; in grid mode, click a card or press Enter/Space to open the edit panel since explicit action buttons are hidden for a cleaner layout.
-
-### Testing and linting
-
-After installing dependencies you can run:
-
-```bash
-cd web
-npm test -- --watch=false
-npm run lint
-```
-
-`web/src/app/pages/add-item/add-item-page.component.spec.ts` contains coverage for the search form, manual draft handoff, CSV upload flows, and UI copy shown in the Add Item tabs.
-
-(Angular CLI creates the recommended lint configuration out of the box.)
-
-### Commit-time lint checks
-
-Copy the shared `pre-commit` hook into your local `.git/hooks` directory so commits are blocked unless both lint suites succeed:
-
-```bash
-cp githooks/pre-commit .git/hooks/pre-commit
-```
-
-The `pre-commit` hook runs `golangci-lint run ./...` and `npm run lint` from `web/`. Set `SKIP_PRECOMMIT_LINT=1` when invoking `git commit` to temporarily bypass the check (for example, when working offline and planning to lint later).
-
-To produce the bundle consumed by the nginx-based UI container, build the production assets so they land in `web/dist/web/browser`:
-
-```bash
-cd web
-npm run build
-```
-
-
-## Deployment notes
-
-* **Docker**: the repository now publishes separate images for the API (`Docker/Dockerfile.api`) and UI (`Docker/Dockerfile.ui`). The Makefile targets `docker-build-api`/`docker-build-ui` (and matching `docker-push`/`docker-buildx` variants) build and publish each image. The UI container writes `assets/runtime-config.js` from the `NG_APP_API_URL` environment variable so preview deployments can point at different backends without rebuilding the Angular assets.
-* **Secrets**: the API automatically loads `DATABASE_URL`, `GOOGLE_BOOKS_API_KEY`, `AUTH_GOOGLE_CLIENT_ID`, and `AUTH_GOOGLE_CLIENT_SECRET` from either the env var or a `<NAME>_FILE` path. Default secret paths include `/run/secrets/anthology_database_url`, `/run/secrets/anthology_google_books_api_key`, `/run/secrets/anthology_google_client_id`, and `/run/secrets/anthology_google_client_secret`, so Swarm/Stack secrets are consumed without baking credentials into the image.
-* **Environment management**: prefer `.env` files for local overrides (`DATA_STORE`, `DATABASE_URL`, `LOG_LEVEL`). Do not commit secrets.
-* **Migrations**: Goose-managed migrations run on API startup; use the Goose CLI for manual `up`/`down` operations if needed.
-
-### Docker secrets quickstart
-
-The container expects these Docker secrets (add the OAuth secrets for all deployments):
-
-| Secret name                       | Environment variable | Description                                      |
-| --------------------------------- | -------------------- | ------------------------------------------------ |
-| `anthology_database_url`          | `DATABASE_URL_FILE`  | Full Postgres connection string                  |
-| `anthology_google_books_api_key`  | `GOOGLE_BOOKS_API_KEY_FILE` | Google Books API key                       |
-| `anthology_google_client_id`      | `AUTH_GOOGLE_CLIENT_ID_FILE` | Google OAuth client ID                    |
-| `anthology_google_client_secret`  | `AUTH_GOOGLE_CLIENT_SECRET_FILE` | Google OAuth client secret            |
-
-Create them once per Swarm and attach them to the stack/service:
-
-```bash
-printf 'postgres://user:pass@db:5432/anthology?sslmode=disable' | docker secret create anthology_database_url -
-printf 'google-books-key' | docker secret create anthology_google_books_api_key -
-printf 'google-client-id' | docker secret create anthology_google_client_id -
-printf 'google-client-secret' | docker secret create anthology_google_client_secret -
-
-# example stack deployment (provide your own stack file)
-docker stack deploy -c stack.yml anthology
-```
-
-Secrets are immutable. To change a value, remove and recreate it, then update the service:
-
-```bash
-docker secret rm anthology_database_url anthology_google_books_api_key anthology_google_client_id anthology_google_client_secret
-printf 'new-connection-string' | docker secret create anthology_database_url -
-printf 'new-google-books-key' | docker secret create anthology_google_books_api_key -
-printf 'new-google-client-id' | docker secret create anthology_google_client_id -
-printf 'new-google-client-secret' | docker secret create anthology_google_client_secret -
-
-docker service update --secret-rm anthology_database_url --secret-rm anthology_google_books_api_key --secret-rm anthology_google_client_id --secret-rm anthology_google_client_secret \
-  --secret-add source=anthology_database_url,target=anthology_database_url \
-  --secret-add source=anthology_google_books_api_key,target=anthology_google_books_api_key \
-  --secret-add source=anthology_google_client_id,target=anthology_google_client_id \
-  --secret-add source=anthology_google_client_secret,target=anthology_google_client_secret \
-  anthology_api
-```
-
-Alternatively, override `DATABASE_URL_FILE`, `GOOGLE_BOOKS_API_KEY_FILE`, `AUTH_GOOGLE_CLIENT_ID_FILE`, and `AUTH_GOOGLE_CLIENT_SECRET_FILE` or set `DATABASE_URL`, `GOOGLE_BOOKS_API_KEY`, `AUTH_GOOGLE_CLIENT_ID`, and `AUTH_GOOGLE_CLIENT_SECRET` directly when not running under Swarm (e.g., local `docker compose up`).
-
-When provisioning Postgres outside of Compose, create the database/user first:
-
-```sql
-CREATE USER anthology WITH PASSWORD 'choose-a-strong-password';
-CREATE DATABASE anthology OWNER anthology;
-GRANT ALL PRIVILEGES ON DATABASE anthology TO anthology;
-```
-
-Use the resulting credentials in your `anthology_database_url` secret (e.g., `postgres://anthology:choose-a-strong-password@db:5432/anthology?sslmode=disable`).
-
-## Further reading
-
-* [Planning document](docs/planning/anthology.md) for the full multi-phase roadmap.
-* [Go startup flow diagram](docs/architecture/go-startup.md) showing how config, repositories, services, and HTTP components initialize.
-* [Angular Material reference](docs/architecture/material-design.md) for theming notes, component usage, and the formatting checklist before shipping UI changes.
-* `internal/items/service_test.go` covers domain validation logic and repository behavior.
-* `web/src/app/pages/items/items-page.component.*` contains the main Angular page that ties the experience together.
+Anthology is available under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ docker run -d --name db --network anthology \
   -v anthology-postgres:/var/lib/postgresql/data \
   postgres:17
 
+until docker exec db pg_isready -U anthology -d anthology >/dev/null 2>&1; do sleep 1; done
+
 docker run -d --name anthology-api --network anthology \
   --env-file anthology.env \
   -p 8080:8080 \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ docker build -f Docker/Dockerfile.ui -t anthology-ui:local .
 Create an untracked `anthology.env` file:
 
 ```dotenv
+# Use production when serving the application over HTTPS.
 APP_ENV=development
 DATABASE_URL=postgres://anthology:change-me@db:5432/anthology?sslmode=disable
 GOOGLE_BOOKS_API_KEY=replace-with-your-api-key


### PR DESCRIPTION
## What changed

- Reworked the root README into a concise, Docker-first self-hosting guide.
- Documented required services, configuration, secrets, migrations, and health checks without private infrastructure details.
- Reduced AGENTS.md to deliberate, public-safe guidance that cannot be inferred easily from code.

## Why

Public users should be able to understand, configure, and run the project without reading source code or organization-specific deployment notes. Agent guidance now stays focused and avoids duplicating the README, Makefile, and codebase.

## Validation

- `make api-test`
- `npm ci && npm test -- --watch=false` (196 tests)
- Built `anthology-api:local` and `anthology-ui:local`
- Smoke-tested UI and API `/health`; confirmed automatic migrations
- Verified external documentation links and README line count
- Scanned changed docs for private infrastructure and credential patterns


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a streamlined Docker-first setup guide covering prerequisites, environment configuration, image building, and running the full application stack.
  * Documented OAuth configuration, service health checks, development commands, and links to additional architecture guidance.
  * Simplified contributor and agent guidance, including testing, deployment configuration, and migration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->